### PR TITLE
update to ubuntu 19.04 and add magik's missing key

### DIFF
--- a/terraform/devnet/miners/main.tf
+++ b/terraform/devnet/miners/main.tf
@@ -3,7 +3,7 @@ resource "packet_device" "miners" {
   hostname            = "devnet-miner-${count.index}"
   plan                = "c1.small.x86"
   facilities          = ["ams1"]
-  operating_system    = "ubuntu_18_04"
+  operating_system    = "ubuntu_19_04"
   billing_cycle       = "hourly"
   project_id          = "${var.project_id}"
   project_ssh_key_ids = ["${values(local.ssh_keys)}"]
@@ -16,6 +16,7 @@ locals {
     whyrusleeping3 = "3890262b-00e2-4b7f-98c5-f748d7e15f46"
     kubuxu         = "2c7b5374-2cd9-4206-9f9d-ca0d443e77f4"
     magik6k        = "d8f6e481-3204-4bd7-8922-81a33a46d28e"
+    magik6k2       = "cbf19736-a4ca-4cd1-8982-6404869edb91"
     magik6k3       = "b6d323cd-773b-4e63-8098-405e9ba5cf9e"
     ognots         = "e0eb55a6-b2e7-48f8-9bd9-a7c5987332dc"
   }


### PR DESCRIPTION
more recent glibc version is needed, so upgrading ubuntu version.
also adds Magik's magical ssh key
this terraform has already been applied