### PR TITLE
add names to certbot cron so they aren't added each time

### DIFF
--- a/ansible/roles/certbot/tasks/main.yml
+++ b/ansible/roles/certbot/tasks/main.yml
@@ -17,7 +17,7 @@
     - python-certbot-nginx
 
 - name: Add crontab to renew certificates
-  cron: minute="30" hour="2" weekday="1" job="/usr/local/bin/certbot renew >> /var/log/le-renew.log"
+  cron: name="renew certificates" minute="30" hour="2" weekday="1" job="/usr/local/bin/certbot renew >> /var/log/le-renew.log"
 
 - name: Add crontab to reload server
-  cron: minute="35" hour="2" weekday="1" job="/etc/init.d/nginx reload"
+  cron: name="reload server" minute="35" hour="2" weekday="1" job="/etc/init.d/nginx reload"


### PR DESCRIPTION
Found that we were adding new cron lines on each run when I ran a `--check --diff` once.

> Note that if name is not set and state=present, then a new crontab entry will always be created, regardless of existing ones.
https://docs.ansible.com/ansible/latest/modules/cron_module.html