### PR TITLE
bugs: missing slash and lotus-miner restart

### DIFF
--- a/ansible/lotus_bootstrap_miner_update_binaries.yml
+++ b/ansible/lotus_bootstrap_miner_update_binaries.yml
@@ -9,6 +9,7 @@
     lotus_copy_binary: false
     lotus_miner_copy_binary: false
     lotus_daemon_restart: false
+    lotus_miner_restart: false
   tasks:
     - name: Copy lotus binary
       copy:
@@ -31,3 +32,8 @@
         name: 'lotus-daemon'
         state: restarted
       when: lotus_daemon_restart | bool
+    - name: restart-lotus-miner
+      systemd:
+        name: 'lotus-miner'
+        state: restarted
+      when: lotus_miner_restart | bool

--- a/ansible/update_binaries.bash
+++ b/ansible/update_binaries.bash
@@ -72,7 +72,8 @@ for HOST in "${HOSTS1[@]}"; do
     -e lotus_miner_binary_src="${LOTUS_SRC}/lotus-storage-miner"      \
     -e lotus_copy_binary=$COPY_BINARY                                 \
     -e lotus_miner_copy_binary=$COPY_BINARY                           \
-    -e lotus_daemon_restart=$RESTART_LOTUS
+    -e lotus_daemon_restart=$RESTART_LOTUS                            \
+    -e lotus_miner_restart=$RESTART_LOTUS                             \
     --limit $HOST                                                     \
     $ANSIBLE_CHECK_MODE                                               \
     $@


### PR DESCRIPTION
misisng slash made it to try execute playbook on all hosts in parallel.
added lotus-miner restart to playbook, as it was advised we keep lotus and lotus-storage-miner versions in sync