### PR TITLE
add volume size for preminers

### DIFF
--- a/terraform2/modules/devnet/main.tf
+++ b/terraform2/modules/devnet/main.tf
@@ -51,6 +51,7 @@ module "preminers" {
   key_name                   = var.key_name
   environment                = var.environment
   network_name               = var.name
+  volume_size                = var.preminer_volume_size
   public_security_group_ids  = [aws_security_group.devnet_public.id]
   private_security_group_ids = [aws_security_group.devnet_private.id]
   private_subnet_id          = var.private_subnet_id

--- a/terraform2/modules/devnet/variables.tf
+++ b/terraform2/modules/devnet/variables.tf
@@ -17,6 +17,10 @@ variable "public_subnet_cidr" {}
 variable "database_subnet_group" {}
 
 variable "preminer_iam_profile" {}
+variable "preminer_volume_size" {
+  type    = number
+  default = 128
+}
 
 # Variables for tools
 variable "toolshed_instance_type" {

--- a/terraform2/modules/lotus_node/main.tf
+++ b/terraform2/modules/lotus_node/main.tf
@@ -11,7 +11,7 @@ resource "aws_instance" "node" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 128
+    volume_size = var.volume_size
   }
 
   tags = {

--- a/terraform2/modules/lotus_node/variables.tf
+++ b/terraform2/modules/lotus_node/variables.tf
@@ -56,3 +56,8 @@ variable "private_subnet_id" {
 variable "public_subnet_id" {
   type = string
 }
+
+variable "volume_size" {
+  type    = number
+  default = 128
+}


### PR DESCRIPTION
When using larger sector sizes (eg; 32GiB) the params alone are 105GB, and the sectors from s3 are ~30GB for the 12TiB of raw power sectors we have, so we need  to be able to configure them to have more disk space.