### PR TITLE
expire redirects

### DIFF
--- a/kubernetes/helm/butterflynet-grafana/templates/nginx-config-sidecar.yaml
+++ b/kubernetes/helm/butterflynet-grafana/templates/nginx-config-sidecar.yaml
@@ -12,9 +12,11 @@ data:
         proxy_pass http://localhost:3000;
       }
       location  = / {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/(chain|login|user) {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/d/ {
@@ -22,6 +24,7 @@ data:
           proxy_pass http://localhost:3000/$uri$args;
         }
         if ($args != "orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk") {
+          expires 1h;
           return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
         }
       }

--- a/kubernetes/helm/calibrationnet-grafana/templates/nginx-config-sidecar.yaml
+++ b/kubernetes/helm/calibrationnet-grafana/templates/nginx-config-sidecar.yaml
@@ -12,9 +12,11 @@ data:
         proxy_pass http://localhost:3000;
       }
       location  = / {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/(chain|login|user) {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/d/ {
@@ -22,6 +24,7 @@ data:
           proxy_pass http://localhost:3000/$uri$args;
         }
         if ($args != "orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk") {
+          expires 1h;
           return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
         }
       }

--- a/kubernetes/helm/lotus-grafana/templates/nginx-config-sidecar.yaml
+++ b/kubernetes/helm/lotus-grafana/templates/nginx-config-sidecar.yaml
@@ -11,9 +11,11 @@ data:
         proxy_pass http://localhost:3000;
       }
       location  = / {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/(chain|login|user) {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/d/ {
@@ -21,6 +23,7 @@ data:
           proxy_pass http://localhost:3000/$uri$args;
         }
         if ($args != "orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk") {
+          expires 1h;
           return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
         }
       }

--- a/kubernetes/helm/nerpanet-grafana/templates/nginx-config-sidecar.yaml
+++ b/kubernetes/helm/nerpanet-grafana/templates/nginx-config-sidecar.yaml
@@ -12,9 +12,11 @@ data:
         proxy_pass http://localhost:3000;
       }
       location  = / {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/(chain|login|user) {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/d/ {
@@ -22,6 +24,7 @@ data:
           proxy_pass http://localhost:3000/$uri$args;
         }
         if ($args != "orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk") {
+          expires 1h;
           return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
         }
       }

--- a/kubernetes/helm/public-calibrationnet-grafana/templates/nginx-config-sidecar.yaml
+++ b/kubernetes/helm/public-calibrationnet-grafana/templates/nginx-config-sidecar.yaml
@@ -12,9 +12,11 @@ data:
         proxy_pass http://localhost:3000;
       }
       location  = / {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/P_Q13JnMz/top-miners-by-block-reward?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/(chain|login|user) {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/P_Q13JnMz/top-miners-by-block-reward?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/d/ {
@@ -22,6 +24,7 @@ data:
           proxy_pass http://localhost:3000/$uri$args;
         }
         if ($args != "orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk") {
+          expires 1h;
           return 301 https://{{ .Values.domain }}/d/P_Q13JnMz/top-miners-by-block-reward?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
         }
       }

--- a/kubernetes/helm/testnet-grafana/templates/nginx-config-sidecar.yaml
+++ b/kubernetes/helm/testnet-grafana/templates/nginx-config-sidecar.yaml
@@ -12,9 +12,11 @@ data:
         proxy_pass http://localhost:3000;
       }
       location  = / {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/(chain|login|user) {
+        expires 1h;
         return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
       }
       location ~ ^/d/ {
@@ -22,6 +24,7 @@ data:
           proxy_pass http://localhost:3000/$uri$args;
         }
         if ($args != "orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk") {
+          expires 1h;
           return 301 https://{{ .Values.domain }}/d/z6FtI92Zz/chain/?orgId=1&refresh={{ .Values.metricsRefresh }}&from=now-{{ .Values.metricsRange }}&to=now&kiosk;
         }
       }


### PR DESCRIPTION
In the event that a different dashboard should be displayed, our
perminent redirects are cached by web browsers. This can lead to
confusion about why the dashboard is displaying old content.