### PR TITLE
move to the alpha overlay for aws-ebs-csi-driver for snapshot feature

### DIFF
--- a/terraform/eks/extra/postinstall.sh
+++ b/terraform/eks/extra/postinstall.sh
@@ -40,11 +40,22 @@ install_efs_csi() {
 }
 
 install_ebs_csi() {
-  kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+  kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/alpha/?ref=master"
+}
+
+install_snapshot_crd() {
+  kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
 }
 
 install_calico() {
   kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.7.2/config/v1.7/calico.yaml
+}
+
+install_storage_classes() {
+  kubectl apply -f storage-ebs-csi-snapclass.yaml
+  kubectl apply -f storage-ebs.yaml
 }
 
 check_kubectl_version
@@ -52,3 +63,4 @@ install_external_dns
 install_efs_csi
 install_ebs_csi
 install_calico
+install_snapshot_crd

--- a/terraform/eks/extra/storage-ebs-csi-snapclass.yaml
+++ b/terraform/eks/extra/storage-ebs-csi-snapclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshotClass
+metadata:
+  name: ebs-csi-snapclass
+deletionPolicy: Delete
+driver: ebs.csi.aws.com


### PR DESCRIPTION
I have applied this update to mainnet-us-east-1, mainnet-eu-central-1, and mainnet-ap-southeast-1.