### PR TITLE
Update stats service file to use new env variables.

### DIFF
--- a/ansible/roles/stats/defaults/main.yml
+++ b/ansible/roles/stats/defaults/main.yml
@@ -1,3 +1,4 @@
+stats_fullnode_multiaddr: /ipv4/127.0.0.1/tcp/1234/http
 stats_golog_log_fmt: json
 stats_golog_log_level: info
 stats_nosync: false

--- a/ansible/roles/stats/templates/stats.service.j2
+++ b/ansible/roles/stats/templates/stats.service.j2
@@ -7,10 +7,12 @@ PartOf=lotus-daemon.service
 [Service]
 User={{ lotus_user }}
 Group={{ lotus_user }}
-ExecStart=/usr/local/bin/stats -repo={{ lotus_path }} -database={{ stats_influxdb_database }} -nosync={{ stats_nosync | lower }}
-Environment=INFLUX_ADDR="{{ stats_influxdb_url }}"
-Environment=INFLUX_USER="{{ stats_influxdb_username }}"
-Environment=INFLUX_PASS="{{ stats_influxdb_password }}"
+ExecStart=/usr/local/bin/stats --nosync={{ stats_nosync | lower }}
+Environment=FULLNODE_API_INFO="{{ stats_fullnode_multiaddr }}"
+Environment=LOTUS_STATS_INFLUX_DATABASE="{{ stats_influx_database }}"
+Environment=LOTUS_STATS_INFLUX_HOSTNAME="{{ stats_influxdb_url }}"
+Environment=LOTUS_STATS_INFLUX_USERNAME="{{ stats_influxdb_username }}"
+Environment=LOTUS_STATS_INFLUX_PASSWORD="{{ stats_influxdb_password }}"
 Environment=GOLOG_FILE="{{ stats_golog_file }}"
 Environment=GOLOG_LOG_LEVEL="{{ stats_golog_log_level }}"
 Environment=GOLOG_LOG_FMT="{{ stats_golog_log_fmt }}"


### PR DESCRIPTION
This change is currently on calibrationnet and butterfly.

Changed to the environment variables in use in the stats binary.

I also changed from using LOTUS_REPO to using FULLNODE_API_INFO even though these are running locally. I had some trouble getting the binary to start reading the API from the repo, which might be something to troubleshoot further, but I got it to work this way.