### PR TITLE
Update all nodes to v1.4.0

### DIFF
--- a/kubernetes/mainnet-ap-southeast-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-ap-southeast-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/base.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v1.3.0
+  tag: 667e006a2
 
 prometheusOperatorServiceMonitor: true
 
@@ -23,7 +23,7 @@ daemonEnvs:
   - name: GOLOG_LOG_FMT
     value: json
   - name: GODEBUG
-    value: madvdontneed=1,gctrace=1
+    value: madvdontneed=1
 
 additionalLabels:
   mode: open

--- a/kubernetes/mainnet-eu-central-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-eu-central-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/base.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v1.3.0
+  tag: 667e006a2
 
 prometheusOperatorServiceMonitor: true
 
@@ -23,7 +23,7 @@ daemonEnvs:
   - name: GOLOG_LOG_FMT
     value: json
   - name: GODEBUG
-    value: madvdontneed=1,gctrace=1
+    value: madvdontneed=1
 
 additionalLabels:
   mode: open

--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/base.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v1.3.0
+  tag: 667e006a2
 
 resources:
   requests:
@@ -29,4 +29,4 @@ daemonEnvs:
   - name: GOLOG_LOG_FMT
     value: json
   - name: GODEBUG
-    value: madvdontneed=1,gctrace=1
+    value: madvdontneed=1

--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/base.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v1.3.0
+  tag: v1.4.0
 
 resources:
   requests:
@@ -20,7 +20,7 @@ daemonEnvs:
   - name: GOLOG_LOG_FMT
     value: json
   - name: GODEBUG
-    value: madvdontneed=1,gctrace=1
+    value: madvdontneed=1
 
 daemonConfig: |
   [API]

--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/base.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v1.3.0
+  tag: v1.4.0
 
 prometheusOperatorServiceMonitor: true
 
@@ -22,7 +22,7 @@ daemonEnvs:
   - name: GOLOG_LOG_FMT
     value: json
   - name: GODEBUG
-    value: madvdontneed=1,gctrace=1
+    value: madvdontneed=1
 
 daemonConfig: |
   [API]


### PR DESCRIPTION
Updates all nodes to v1.4.0, the bootstrap are running the following patch

```diff
➜  lotus git:(e9989d0e4) ✗ git diff v1.4.0 667e006a2
diff --git a/node/modules/lp2p/pubsub.go b/node/modules/lp2p/pubsub.go
index 9724eb3b4..c702e62c9 100644
--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -226,7 +226,7 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
                                AppSpecificWeight: 1,

                                // This sets the IP colocation threshold to 5 peers before we apply penalties
-                               IPColocationFactorThreshold: 5,
+                               IPColocationFactorThreshold: 256,
                                IPColocationFactorWeight:    -100,
                                // TODO we want to whitelist IPv6 /64s that belong to datacenters etc
                                // IPColocationFactorWhitelist: map[string]struct{}{},
```