### PR TITLE
remove filecoin user when building binaries

### DIFF
--- a/docker/Dockerfile.lotus
+++ b/docker/Dockerfile.lotus
@@ -4,24 +4,17 @@ ARG BUILDER_BASE=builder-local
 # builder-base
 # ---------------------
 
-FROM golang:1.15.5 AS builder-deps
+FROM golang:1.15.6 AS builder-deps
 MAINTAINER Lotus Development Team
 
 RUN apt-get update && apt-get install -y ca-certificates build-essential clang ocl-icd-opencl-dev ocl-icd-libopencl1 jq libhwloc-dev
 
-ARG UID=1000
-ARG GID=1000
 ARG RUST_VERSION=nightly
 ENV XDG_CACHE_HOME="/tmp"
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
-
-RUN addgroup -gid $GID filecoin && \
-    adduser --no-create-home --disabled-password -uid $UID --ingroup filecoin --gecos "" filecoin && \
-    mkdir -p "/go/pkg/mod" && \
-    chown -R filecoin:filecoin "/go/pkg/mod"
 
 RUN wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"; \
     chmod +x rustup-init; \
@@ -64,9 +57,6 @@ RUN make clean deps
 FROM $BUILDER_BASE AS builder
 MAINTAINER Lotus Development Team
 
-RUN chown -R filecoin:filecoin /opt/filecoin
-
-USER filecoin
 WORKDIR /opt/filecoin
 
 ARG RUSTFLAGS=""


### PR DESCRIPTION
I couldn't compile Lotus using this `Dockerfile.lotus` when compiling from `feat/splitstore` branch. I got errors like:

```
#15 58.33 /go/pkg/mod/github.com/!geert!johan/go.rice@v1.0.0/rice/templates.go:12:2: github.com/valyala/fasttemplate@v1.0.1: verifying module: github.com/valyala/fasttemplate@v1.0.1: open /go/pkg/sumdb/sum.golang.org/latest: no such file or directory
```


For some reason `master` and `v1.4.0` somehow compiled fine, using the command:

```
➜  docker build --target lotus --build-arg BUILDER_BASE=builder-git --build-arg TAG=feat/splitstore  -t nonsens3/lotus:splitstore-debug -f Dockerfile.lotus .
```

It seems like the problem is solved when we don't introduce the `filecoin` user, and it also looks like we don't need it, because the base image later in the build process created `fc` user, which can execute the binaries.