### PR TITLE
Update build scripts to support network flag

### DIFF
--- a/ansible/UPGRADING_LEGACY_SPACERACE_INFRA.md
+++ b/ansible/UPGRADING_LEGACY_SPACERACE_INFRA.md
@@ -14,7 +14,7 @@ $ git clone https://github.com/filecoin-project/lotus.git --branch <branch/tag> 
 2. Run a build of the code and required binaries to update
 
 ```
-$ ../scripts/build_binaries.bash --src /tmp/<branch/tag> -- lotus lotus-miner lotus-seed lotus-shed lotus-stats
+$ ../scripts/build_binaries.bash --src /tmp/<branch/tag> --network <network> -- lotus lotus-miner lotus-seed lotus-shed lotus-stats
 ```
 
 3. Check update

--- a/docker/Dockerfile.lotus
+++ b/docker/Dockerfile.lotus
@@ -9,19 +9,12 @@ MAINTAINER Lotus Development Team
 
 RUN apt-get update && apt-get install -y ca-certificates build-essential clang ocl-icd-opencl-dev ocl-icd-libopencl1 jq libhwloc-dev
 
-ARG UID=1000
-ARG GID=1000
 ARG RUST_VERSION=nightly
 ENV XDG_CACHE_HOME="/tmp"
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
-
-RUN addgroup -gid $GID filecoin && \
-    adduser --no-create-home --disabled-password -uid $UID --ingroup filecoin --gecos "" filecoin && \
-    mkdir -p "/go/pkg/mod" && \
-    chown -R filecoin:filecoin "/go/pkg/mod"
 
 RUN wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"; \
     chmod +x rustup-init; \
@@ -72,16 +65,13 @@ RUN make clean deps
 FROM $BUILDER_BASE AS builder
 MAINTAINER Lotus Development Team
 
-RUN chown -R filecoin:filecoin /opt/filecoin
-
-USER filecoin
 WORKDIR /opt/filecoin
 
 ARG RUSTFLAGS
 ARG FFI_BUILD_FROM_SOURCE
 ARG GOFLAGS
 
-RUN make deps lotus lotus-miner lotus-worker lotus-shed lotus-chainwatch lotus-stats
+RUN make lotus lotus-miner lotus-worker lotus-shed lotus-chainwatch lotus-stats
 
 # ---------------------
 # base
@@ -199,7 +189,7 @@ CMD ["-help"]
 FROM base AS shed
 MAINTAINER Lotus Development Team
 
-RUN apt-get update && apt-get install -y jq curl net-tools dnsutils
+RUN apt-get update && apt-get install -y jq curl net-tools dnsutils netcat wget rsync
 
 COPY --from=builder /opt/filecoin/lotus      /usr/local/bin/
 COPY --from=builder /opt/filecoin/lotus-shed /usr/local/bin/

--- a/scripts/build_containers.bash
+++ b/scripts/build_containers.bash
@@ -2,13 +2,27 @@
 
 set -xe
 
+# Examples usages
+#
+# building a tagged release for the calibration network
+# ./build_containers.bash --tag v1.5.0-pre1 --network calibnet
+#
+# building local source code
+# ./build_containers.bash --src $GOPATH/src/github.com/filecoin-project/lotus --network calibnet
+#
+#
+# if you need to override the docker tag, you can specify the `--docker-tag` flag
+
 usage() {
   set +x
-  echo "usage: build_binaries.bash
-    [--src    ] location of source code to build
-    [--tag    ] tag to build
-    [--repo   ] docker repo to retag contains as and push
-    [--native ] build the filecoin ffi natively"
+  echo "usage: build_containers.bash
+    [--src        ] location of source code to build
+    [--tag        ] tag to build
+    [--docker-tag ] override the default docker tag of <network>-<commit|tag>
+    [--network    ] name of network to build
+    [--repo       ] docker repo to retag contains as and push
+    [--native     ] build the filecoin ffi natively
+    [--no-cache   ] pass the --no-cache flag to docker when building"
 }
 
 while [ "$1" != "" ]; do
@@ -20,14 +34,15 @@ while [ "$1" != "" ]; do
                                 tag="$1"
                                 ;;
         --docker-tag )          shift
-				docker_tag="$1"
+                                docker_tag="$1"
+                                ;;
+        --network )             shift
+                                network="$1"
                                 ;;
         --repo )                shift
                                 repo="$1"
                                 ;;
         --native )              native=true
-                                ;;
-        --calibnet )            calibnet=true
                                 ;;
         --no-cache )            nocache="--no-cache"
                                 ;;
@@ -47,6 +62,7 @@ BUILD_SRC="${src:-"$GOPATH/src/github.com/filecoin-project/lotus"}"
 BUILD_FFI="${native:-""}"
 BUILD_TAG="${tag:-""}"
 BUILD_REPO="${repo:-""}"
+NETWORK="${network:-"mainnet"}"
 DOCKER_NOCACHE="${nocache:-""}"
 
 if ! docker info 2>&1 > /dev/null ; then
@@ -60,10 +76,8 @@ export DOCKER_BUILDKIT=1
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd "$SCRIPTDIR/../docker"
 
-goflags=()
-if [ "$calibnet" = true ]; then
-  goflags=(--build-arg=GOFLAGS="-tags='calibnet'")
-fi
+goflags=(--build-arg=GOFLAGS="-tags='$NETWORK'")
+
 ffiargs=()
 if [ "$BUILD_FFI" = true ]; then
   ffiargs=(--build-arg=RUSTFLAGS="-C target-cpu=native -g" --build-arg=FFI_BUILD_FROM_SOURCE="1")
@@ -72,10 +86,14 @@ fi
 buildargs=()
 if [ ! -z "$BUILD_TAG" ]; then
   buildargs=(--build-arg=BUILDER_BASE=builder-git --build-arg=TAG=$BUILD_TAG)
-  tag="$BUILD_TAG"
+  tag="$NETWORK-$BUILD_TAG"
 else
   buildargs=(--build-arg=BUILDER_BASE=builder-local)
-  tag=$(git -C $BUILD_SRC describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
+  tag="$NETWORK-$(git -C $BUILD_SRC describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)"
+fi
+
+if [ -z $docker_tag ]; then
+  docker_tag="$tag"
 fi
 
 docker build --progress=plain $DOCKER_NOCACHE -t "lotus:$docker_tag"            -f Dockerfile.lotus "${ffiargs[@]}" "${goflags[@]}" "${buildargs[@]}" --target=lotus $(dirname $BUILD_SRC)
@@ -83,7 +101,6 @@ docker build --progress=plain $DOCKER_NOCACHE -t "lotus-shed:$docker_tag"       
 docker build --progress=plain $DOCKER_NOCACHE -t "lotus-stats:$docker_tag"      -f Dockerfile.lotus "${ffiargs[@]}" "${goflags[@]}" "${buildargs[@]}" --target=stats $(dirname $BUILD_SRC)
 docker build --progress=plain $DOCKER_NOCACHE -t "lotus-miner:$docker_tag"      -f Dockerfile.lotus "${ffiargs[@]}" "${goflags[@]}" "${buildargs[@]}" --target=miner $(dirname $BUILD_SRC)
 docker build --progress=plain $DOCKER_NOCACHE -t "lotus-worker:$docker_tag"     -f Dockerfile.lotus "${ffiargs[@]}" "${goflags[@]}" "${buildargs[@]}" --target=worker $(dirname $BUILD_SRC)
-docker build --progress=plain $DOCKER_NOCACHE -t "lotus-chainwatch:$docker_tag" -f Dockerfile.lotus "${ffiargs[@]}" "${goflags[@]}" "${buildargs[@]}" --target=chainwatch $(dirname $BUILD_SRC)
 
 if [ ! -z "$BUILD_REPO" ]; then
   docker tag "lotus:$docker_tag"            "$BUILD_REPO/lotus:$docker_tag"
@@ -91,29 +108,12 @@ if [ ! -z "$BUILD_REPO" ]; then
   docker tag "lotus-stats:$docker_tag"      "$BUILD_REPO/lotus-stats:$docker_tag"
   docker tag "lotus-miner:$docker_tag"      "$BUILD_REPO/lotus-miner:$docker_tag"
   docker tag "lotus-worker:$docker_tag"     "$BUILD_REPO/lotus-worker:$docker_tag"
-  docker tag "lotus-chainwatch:$docker_tag" "$BUILD_REPO/lotus-chainwatch:$docker_tag"
 
   docker push "$BUILD_REPO/lotus:$docker_tag"
   docker push "$BUILD_REPO/lotus-shed:$docker_tag"
   docker push "$BUILD_REPO/lotus-stats:$docker_tag"
   docker push "$BUILD_REPO/lotus-miner:$docker_tag"
   docker push "$BUILD_REPO/lotus-worker:$docker_tag"
-  docker push "$BUILD_REPO/lotus-chainwatch:$docker_tag"
-
-  docker tag "lotus:$docker_tag"            "$BUILD_REPO/lotus:latest"
-  docker tag "lotus-shed:$docker_tag"       "$BUILD_REPO/lotus-shed:latest"
-  docker tag "lotus-stats:$docker_tag"      "$BUILD_REPO/lotus-stats:latest"
-  docker tag "lotus-miner:$docker_tag"      "$BUILD_REPO/lotus-miner:latest"
-  docker tag "lotus-worker:$docker_tag"     "$BUILD_REPO/lotus-worker:latest"
-  docker tag "lotus-chainwatch:$docker_tag" "$BUILD_REPO/lotus-chainwatch:latest"
-
-  docker push "$BUILD_REPO/lotus:latest"
-  docker push "$BUILD_REPO/lotus-shed:latest"
-  docker push "$BUILD_REPO/lotus-stats:latest"
-  docker push "$BUILD_REPO/lotus-miner:latest"
-  docker push "$BUILD_REPO/lotus-worker:latest"
-  docker push "$BUILD_REPO/lotus-chainwatch:latest"
 fi
 
 popd
-


### PR DESCRIPTION
This adds a `--network` flag to both the binary and container build scripts that set the tag for the network.

Example usage for containers.
```
# Examples usages
#
# building a tagged release for the calibration network
# ./build_containers.bash --tag v1.5.0-pre1 --network calibnet
#
# building local source code
# ./build_containers.bash --src $GOPATH/src/github.com/filecoin-project/lotus --network calibnet
#
#
# if you need to override the docker tag, you can specify the `--docker-tag` flag
```