### PR TITLE
Remove volumesnap from the bootstrap nodes

### DIFF
--- a/kubernetes/mainnet-ap-southeast-1-eks/helm/config.yaml
+++ b/kubernetes/mainnet-ap-southeast-1-eks/helm/config.yaml
@@ -7,28 +7,6 @@ deployments:
     name: efs-access
     values:
       - efs-access
-  # volume snapshotter
-  - chart: filecoin/volume-snapshotter
-    version: 0.1.0
-    namespace: ntwk-mainnet-bootstrap
-    name: vsnap-datastore-volume-bootstrap-6-lotus-0
-    values:
-      - base
-      - bootstrap-6
-  - chart: filecoin/volume-snapshotter
-    version: 0.1.0
-    namespace: ntwk-mainnet-bootstrap
-    name: vsnap-datastore-volume-bootstrap-7-lotus-0
-    values:
-      - base
-      - bootstrap-7
-  - chart: filecoin/volume-snapshotter
-    version: 0.1.0
-    namespace: ntwk-mainnet-bootstrap
-    name: vsnap-datastore-volume-bootstrap-8-lotus-0
-    values:
-      - base
-      - bootstrap-8
   # bootstrap
   - chart: filecoin/lotus-fullnode
     version: 0.2.0

--- a/kubernetes/mainnet-eu-central-1-eks/helm/config.yaml
+++ b/kubernetes/mainnet-eu-central-1-eks/helm/config.yaml
@@ -7,28 +7,6 @@ deployments:
     name: efs-access
     values:
       - efs-access
-  # volume snapshotter
-  - chart: filecoin/volume-snapshotter
-    version: 0.1.0
-    namespace: ntwk-mainnet-bootstrap
-    name: vsnap-datastore-volume-bootstrap-3-lotus-0
-    values:
-      - base
-      - bootstrap-3
-  - chart: filecoin/volume-snapshotter
-    version: 0.1.0
-    namespace: ntwk-mainnet-bootstrap
-    name: vsnap-datastore-volume-bootstrap-4-lotus-0
-    values:
-      - base
-      - bootstrap-4
-  - chart: filecoin/volume-snapshotter
-    version: 0.1.0
-    namespace: ntwk-mainnet-bootstrap
-    name: vsnap-datastore-volume-bootstrap-5-lotus-0
-    values:
-      - base
-      - bootstrap-5
   # bootstrap
   - chart: filecoin/lotus-fullnode
     version: 0.2.0

--- a/kubernetes/mainnet-us-east-1-eks/helm/config.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/config.yaml
@@ -7,28 +7,6 @@ deployments:
     name: lotus-stats
     values:
       - lotus-stats
-  # volume snapshotter
-  - chart: filecoin/volume-snapshotter
-    version: 0.1.0
-    namespace: ntwk-mainnet-bootstrap
-    name: vsnap-datastore-volume-bootstrap-0-lotus-0
-    values:
-      - base
-      - bootstrap-0
-  - chart: filecoin/volume-snapshotter
-    version: 0.1.0
-    namespace: ntwk-mainnet-bootstrap
-    name: vsnap-datastore-volume-bootstrap-1-lotus-0
-    values:
-      - base
-      - bootstrap-1
-  - chart: filecoin/volume-snapshotter
-    version: 0.1.0
-    namespace: ntwk-mainnet-bootstrap
-    name: vsnap-datastore-volume-bootstrap-2-lotus-0
-    values:
-      - base
-      - bootstrap-2
   - chart: filecoin/volume-snapshotter
     version: 0.1.0
     namespace: ntwk-mainnet-fullnode


### PR DESCRIPTION
Bootstrap nodes don't need to have their volumes snapshotted, instead should just be recovered from a chain snapshot.