### PR TITLE
Add required env vars for fountain recaptcha

### DIFF
--- a/ansible/roles/lotus_fountain/templates/lotus-fountain.service.j2
+++ b/ansible/roles/lotus_fountain/templates/lotus-fountain.service.j2
@@ -11,6 +11,8 @@ ExecStart=/usr/local/bin/lotus-fountain run --front "127.0.0.1:7777" --from "{{ 
 Environment=LOTUS_PATH="{{ lotus_path }}"
 Environment=GOLOG_FILE="{{ lotus_fountain_golog_file }}"
 Environment=GOLOG_LOG_FMT="{{ lotus_fountain_golog_log_fmt }}"
+Environment=RECAPTCHA_SECRET_KEY="{{ lotus_fountain_recaptcha_secret_key }}"
+Environment=RECAPTCHA_SITE_KEY="{{ lotus_fountain_recaptcha_site_key }}"
 {% for item in lotus_fountain_env | dict2items -%}
 Environment={{ item.key }}="{{ item.value }}"
 {% endfor %}

--- a/ansible/roles/lotus_fountain/vars/main.yml
+++ b/ansible/roles/lotus_fountain/vars/main.yml
@@ -1,2 +1,4 @@
 required_vars:
   - lotus_fountain_address
+  - lotus_fountain_recaptcha_secret_key
+  - lotus_fountain_recaptcha_site_key


### PR DESCRIPTION
The values can be found in the `filecoin dev` vault under `Filecoin Development Networks reCAPTCHA`, they will need to be added in a vault under `inventories/<network>/group_vars/faucet/recaptcha.vault.yml`