### PR TITLE
Update fullnode 6 & 7 to v1.5.0

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/fullnode-6.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/fullnode-6.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: mainnet-v1.5.0
+
 secrets:
   libp2p:
     enabled: true
@@ -6,6 +9,12 @@ secrets:
   jwt:
     enabled: true
     secretName: fullnode-6-jwt-secrets
+
+daemonEnvs:
+  - name: GOLOG_LOG_FMT
+    value: json
+  - name: GODEBUG
+    value: madvdontneed=1
 
 importSnapshot:
   enabled: true

--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/fullnode-7.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/fullnode-7.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: mainnet-v1.5.0
+
 secrets:
   libp2p:
     enabled: true
@@ -6,6 +9,12 @@ secrets:
   jwt:
     enabled: true
     secretName: fullnode-7-jwt-secrets
+
+daemonEnvs:
+  - name: GOLOG_LOG_FMT
+    value: json
+  - name: GODEBUG
+    value: madvdontneed=1
 
 importSnapshot:
   enabled: true


### PR DESCRIPTION
We are running a build to skip pre-migrations on the other full archive nodes.