### PR TITLE
Fix eu bootstrap resources

### DIFF
--- a/kubernetes/mainnet-eu-central-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-eu-central-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/base.yaml
@@ -28,3 +28,8 @@ daemonEnvs:
 
 additionalLabels:
   network: mainnet
+
+resources:
+  requests:
+    memory: 32Gi
+    cpu: 4


### PR DESCRIPTION
this is the same resource allocations we use in our other regions and were just missing from here
without these the bootstrap nodes suffer from over allocated node colocation resulting in degraded performance