### PR TITLE
scale fullnode datastore volumes to 8TB

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/base.yaml
@@ -38,4 +38,4 @@ persistence:
   datastore:
     enabled: true
     storageClassName: "ebs-csi"
-    size: "4000Gi"
+    size: "8000Gi"

--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/fullnode-1.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/fullnode-1.yaml
@@ -9,6 +9,3 @@ secrets:
   jwt:
     enabled: true
     secretName: fullnode-1-jwt-secrets
-persistence:
-  datastore:
-    size: "6000Gi"

--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-fullnode/filecoin/lotus-fullnode/base.yaml
@@ -39,4 +39,4 @@ persistence:
   datastore:
     enabled: true
     storageClassName: "ebs-csi"
-    size: "4000Gi"
+    size: "8000Gi"


### PR DESCRIPTION
datastores were soon to exceed EBS volume capactiy assigned in PVCs
this changes the base.yml default to 8000Gi giving us some time until scaling required again
change has already been rolled out manually using kubectl, this PR is strictly a backfill