### PR TITLE
circle trigger by actions

### DIFF
--- a/.github/workflows/trigger-devnet-reset.yaml
+++ b/.github/workflows/trigger-devnet-reset.yaml
@@ -4,11 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       override_tag:
-        description: "for helm jobs, change image.tag"
+        description: "lotus tag"
       lotus_install_network:
-        description: "for devnet reset, install this version of lotus."
+        description: "network to build lotus tools"
+        default: "butterflynet"
       lotus_deploy_network:
-        description: "for devnet jobs, network name used for finding the ansible hosts file"
+        description: "network to find ansible host"
+        default: "butterfly.fildev.network"
       slack_channel:
         description: "the slack channel where notifications are sent"
         default: "netops-circleci-test"

--- a/.github/workflows/trigger-devnet-upgrade.yaml
+++ b/.github/workflows/trigger-devnet-upgrade.yaml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       override_tag:
-        description: "for helm jobs, change image.tag"
+        description: "lotus tag"
       lotus_deploy_network:
-        description: "for devnet jobs, network name used for finding the ansible hosts file"
+        description: "network to find ansible host"
+        default: "butterfly.fildev.network"
       slack_channel:
         description: "the slack channel where notifications are sent"
         default: "netops-circleci-test"

--- a/.github/workflows/trigger-helm-deploy.yaml
+++ b/.github/workflows/trigger-helm-deploy.yaml
@@ -4,19 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       namespace:
-        description: "for helm jobs, the kubernetes namespace"
+        description: "kubernetes namespace"
       release:
-        description: "for helm jobs, the helm release"
+        description: "helm release"
       chart:
-        description: "for helm jobs, the helm chart"
+        description: "the helm chart"
       chart_version:
-        description: "for helm jobs, the helm chart version"
+        description: "the helm chart version"
       helm_append:
-        description: "for helm jobs, append this to the end of the helm command (i.e to add more -set's)"
+        description: "append this to the end of the helm command (i.e to add more -set's)"
       override_repository:
-        description: "for helm jobs, change image.repository"
+        description: "helm chart image.repository"
       override_tag:
-        description: "for helm jobs, change image.tag"
+        description: "helm chart image.tag"
       slack_channel:
         description: "the slack channel where notifications are sent"
         default: "netops-circleci-test"

--- a/.github/workflows/trigger-lotus-rollout.yaml
+++ b/.github/workflows/trigger-lotus-rollout.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       override_tag:
-        description: "for helm jobs, change image.tag"
+        description: "lotus tag"
       slack_channel:
         description: "the slack channel where notifications are sent"
         default: "netops-circleci-test"


### PR DESCRIPTION
trigger new-fangled circleci jobs using github workflows.


All this does is create a github UI for starting the circleci jobs.


Also, in case you are wondering, the reason why it's split up into multiple actions is that there are a maximum of 10 inputs. Otherwise, I'd have justhad one.

Here's an example of what they look like.


![action](https://user-images.githubusercontent.com/8444698/118343136-f703f000-b4db-11eb-8451-6d5f06bbfe4e.png)
