### PR TITLE
prevent kernel updates

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -4,6 +4,11 @@
   apt:
     update_cache: true
 
+- name: prevent kernel updates
+  dpkg_selections:
+    name: linux-image-aws
+    selection: hold
+
 - name: Install tools
   package:
     name:


### PR DESCRIPTION
This should be a temporary solution, if it is merged at all. Make sure the kernel can't be updated so nvidia drivers can't be inadvertently uninstalled by reboot.