### PR TITLE
set data and nodedata to the same directory

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-dealbot/filecoin/dealbot/dealbot-0.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-dealbot/filecoin/dealbot/dealbot-0.yaml
@@ -60,7 +60,7 @@ daemon:
     enabled: true
     claimName: chain-exports
     mountPath: /efs
-    data: /efs/dealbot/mainnet/data
+    data: /efs/dealbot/mainnet/nodedata
     nodedata: /efs/dealbot/mainnet/nodedata
   resources:
     limits:


### PR DESCRIPTION
DEALBOT_NODE_DATA_DIRECTORY and DEALBOT_DATA_DIRECTORY should be set to the same directory for this deployment