### PR TITLE
add direct lotus release automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,6 +436,92 @@ jobs:
       #       git commit -am "automated genesis build"
       #       git push origin HEAD:new-genesis-$(date +%d%h%y-%H%M)
 
+  lotus-release-update-calibration:
+    parameters:
+      # This can be any git ref (eg: branch, tag, commit)
+      branch:
+        type: string
+        default: "NeVeRmAtCh"
+      group:
+        type: string
+        default: "NeVeRmAtCh"
+    machine:
+      image: ubuntu-2004:202010-01
+      docker_layer_caching: true
+    resource_class: 2xlarge
+    environment:
+      LOTUSROOT: /home/circleci/.go_workspace/src/github.com/filecoin-project/lotus
+    steps:
+      - slack/notify:
+          event: always
+          channel: "#netops-circleci-test"
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "LOTUS RELEASE TESTNET UPDATE :filecoin-new:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A lotus release has triggered an update to the calibration network.\n\n*release*: << parameters.branch >>\n*group*: << parameters.group >>\n\n"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "url": "${CIRCLE_BUILD_URL}",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View on CircleCI"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+      - checkout
+      - aws-cli/install
+      - rust/install
+      - run:
+          name: install golang
+          command: |
+            curl -LOs https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
+      # - go/install:
+      #     version: 1.16.5
+      #     cache-key: v1.16.5
+      - ansible-playbook/install
+      - git-clone:
+          repo: https://github.com/filecoin-project/lotus
+          where: $LOTUSROOT
+          branch: << parameters.branch >>
+      - run:
+          name: setup vault secrets
+          command: |
+            cd ansible
+            echo $ANSIBLE_VAULT_PASSWORD > .vault_password
+      - run:
+          name: update << parameters.group >>
+          command: |
+            args=(
+              "--network" "calibration.fildev.network"
+              "--src" "$LOTUSROOT"
+              "--reboot-daemon"
+              "--" "--limit" "<< parameters.group >>"
+            )
+            cd ansible
+            unset GOPATH
+            ./upgrade_fildev_network_binaries.bash "${args[@]}"
+
   lotus-ansible-upgrade:
     parameters:
       deploy_network:
@@ -685,6 +771,30 @@ workflows:
           build_flags: ""
           branch: << pipeline.parameters.override_tag >>
           check: false
+
+  # workflow to trigger when lotus creates a release
+
+  api-lotus-release-automation:
+    when:
+      and:
+        - equal:
+            - "api-lotus-release-automation"
+            - << pipeline.parameters.api_workflow_requested >>
+    jobs:
+      - lotus-release-update-calibration:
+          name: update-canary
+          branch: << pipeline.parameters.release >>
+          group: canary
+      - hold-for-approval:
+          type: approval
+          requires:
+            - update-canary
+      - lotus-release-update-calibration:
+          name: update-all
+          branch: << pipeline.parameters.release >>
+          group: all
+          requires:
+            - hold-for-approval
 
   api-lotus-rollout:
     when:

--- a/.github/trigger-lotus-release-automation
+++ b/.github/trigger-lotus-release-automation
@@ -1,0 +1,23 @@
+---
+name: trigger-lotus-release-automation
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "lotus release tag"
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger
+        uses: promiseofcake/circleci-trigger-action@v1
+        with:
+          user-token: ${{ secrets.CIRCLE_TOKEN }}
+          project-slug: filecoin-project/lotus-infra
+          branch: master
+          payload: |
+            {
+              "api_workflow_requested": "lotus-devnet-ansible-upgrade",
+              "release": "${{ github.event.inputs.release }}",
+            }

--- a/ansible/inventories/calibration.fildev.network/hosts.yml
+++ b/ansible/inventories/calibration.fildev.network/hosts.yml
@@ -56,6 +56,12 @@ all:
           hosts:
             scratch-1.calibration.fildev.network:
 
+    canary:
+      children:
+        bootstrap0:
+        preminer0:
+        scratch0:
+
     t01000:
       children:
         preminer0:

--- a/ansible/lotus_update.yml
+++ b/ansible/lotus_update.yml
@@ -51,3 +51,14 @@
       force_apt_get: yes
   tasks:
     - include_role: name=lotus_fullnode
+
+- hosts: lotus_daemon
+  become: true
+  vars:
+    upgrade_reboot_daemon: "no"
+  tasks:
+    - name: reboot lotus daemon
+      service:
+        name: lotus-daemon
+        state: restarted
+      when: upgrade_reboot_daemon == "yes"

--- a/ansible/upgrade_fildev_network_binaries.bash
+++ b/ansible/upgrade_fildev_network_binaries.bash
@@ -13,6 +13,8 @@ while [ "$1" != "" ]; do
         -b | --build-flags )    shift
                                 buildflags="$1"
                                 ;;
+        -r | --reboot-daemon)   rebootdaemon=true
+                                ;;
         --check )               ansible_args+=("--check")
                                 ;;
         --verbose )             ansible_args+=("-v")
@@ -24,6 +26,7 @@ while [ "$1" != "" ]; do
 done
 
 hostfile="inventories/${network}/hosts.yml"
+reboot_daemon="${rebootdaemon:-"false"}"
 network_name="${network%%.*}net"
 build_flags="${buildflags:-""}"
 lotus_src="${src:-"$GOPATH/src/github.com/filecoin-project/lotus"}"
@@ -35,5 +38,6 @@ network_flag=$(ansible -o -i $hostfile -b -m debug -a 'msg="{{ network_flag }}"'
 # runs all the roles
 ansible-playbook -i $hostfile lotus_update.yml \
     -e binary_src="$lotus_src"                 \
+    -e upgrade_reboot_daemon="no"              \
     --vault-password-file .vault_password      \
-    --diff "${ansible_args[@]}"
+    --diff "${ansible_args[@]}" "${@}"


### PR DESCRIPTION
Adds a direct workflow to manage lotus release automation to the calibration network. We can slowly build up this release pipeline over time. Pipeline will push out the release to a limited number of nodes in the `canary` ansible group of the calibration ansible hosts file. Upon verification that the release is good, someone will need to approve the rest of the rollout.

This workflow is designed to be triggered automatically via a github webhook. The trigging of the circleci workflow is handled by the [strudy journey](https://github.com/filecoin-project/sturdy-journey/) project ([handler](https://github.com/filecoin-project/sturdy-journey/blob/b89ca3a8920e1bf2109aac25f36003c3c786e2ec/journey/lotus/lotus.go#L99-L127)).

A webhook will need to be configured in the lotus project repo
```
Payload URL: https://lb.mainnet-us-east-2-dev.fildevops.net/sturdy-journey/4108a7d174984d1b64eee6cbcea63b294def2efa/filecoin-project/lotus/github-webhook
Content Type: application/json
Secret: (see Sturdy Journey: Lotus under filecoin dev vault in 1password)
Which events would you like to trigger this webhook?:
Let me select individual events.
[x] Release
```
This is also document in `Sturdy Journey: Lotus` of the `filecoin dev` vault of 1password.

This workflow will also be available through the [lotus-infra github actions workflows](https://github.com/filecoin-project/lotus-infra/actions/workflows/trigger-lotus-release-automation.yaml)

Notifications will be sent to the `#netops-circleci-test` channel in the PL slack (this can later be changed to `#project-lotus`)
![Screen Shot 2021-08-05 at 3 21 49 PM](https://user-images.githubusercontent.com/165274/128428851-687d9981-ea5f-4211-ae53-7db49da9e7c7.png)

Click the `View on CircleCI` will take you to the CircleCI workflow job.

![Screen Shot 2021-08-05 at 3 36 10 PM](https://user-images.githubusercontent.com/165274/128430253-86cecee3-29c4-481d-aa82-7bf1cc045db5.png)

This screen will show you the steps being taken to update the canary nodes of the calibration network. These are `bootstrap-0`, `preminer-0`, and `scratch-0` and are defined in the [calibration networks host file](https://github.com/filecoin-project/lotus-infra/blob/9d3cbd17fd7ae2df1361b4cea138cccddbee9603/ansible/inventories/calibration.fildev.network/hosts.yml#L59-L63). In the same file you can find the hostnames for ssh.

These canary hosts will automatically be updated. Once the release shows that it's stable, a user *must* approve the release to be rolled out to the rest of the calibration hosted infrastructure.

![Screen Shot 2021-08-05 at 3 38 59 PM](https://user-images.githubusercontent.com/165274/128430351-951d8bef-a788-43c2-ad46-c4f4d5645c15.png)
_clicking on the hold-for-approval box will prompt the user to approve the workflow so it can continue_
![Screen Shot 2021-08-05 at 3 39 28 PM](https://user-images.githubusercontent.com/165274/128430355-72d9dacd-536c-4448-88f1-3f582e656c5d.png)

Once the hold is approved, a second message will be sent to the slack channel `#netops-circleci-test`. This notification differs from the previous, in that, the targeted group is `all`. This means that an update is being applied to all calibration hosted infra that is managed by ansible.

![Screen Shot 2021-08-05 at 3 47 19 PM](https://user-images.githubusercontent.com/165274/128430996-f4a39cc6-542b-4d67-8d75-cfcb0253e2f7.png)

If a release is not considered stable, and a rollout to additional calibration hosts is not desired you need to cancel the workflow.
![Screen Shot 2021-08-05 at 4 14 16 PM](https://user-images.githubusercontent.com/165274/128433170-7e501dd2-0008-41d3-a7aa-b2c604ca9256.png)

If a release needs to be rolled back completely, you should run the https://github.com/filecoin-project/lotus-infra/actions/workflows/trigger-devnet-upgrade.yaml workflow.

