### PR TITLE
add failure message when there are helm failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ jobs:
             if [ ! -z "$DOCKER_REPO" ]; then HELM_APPEND=" --set image.repository=${DOCKER_REPO} ${HELM_APPEND}"; fi
             echo "all helm overrides being applied:"
             echo $HELM_APPEND
-            helm --wait --wait-for-jobs --namespace << parameters.namespace >> upgrade --install << parameters.release >> << parameters.chart >> --version << parameters.chart_version >> --values kubernetes/<< parameters.cluster >>/helm/<< parameters.namespace >>/<< parameters.chart >>/base.yaml --values kubernetes/<< parameters.cluster >>/helm/<< parameters.namespace >>/<< parameters.chart >>/<< parameters.release >>.yaml $HELM_APPEND
+            helm --namespace << parameters.namespace >> upgrade --wait --install --timeout 30m0s << parameters.release >> << parameters.chart >> --version << parameters.chart_version >> --values kubernetes/<< parameters.cluster >>/helm/<< parameters.namespace >>/<< parameters.chart >>/base.yaml --values kubernetes/<< parameters.cluster >>/helm/<< parameters.namespace >>/<< parameters.chart >>/<< parameters.release >>.yaml $HELM_APPEND
       - slack/notify:
           event: fail
           channel: << pipeline.parameters.slack_channel >>


### PR DESCRIPTION
fixes: https://github.com/filecoin-project/lotus-infra-archive/issues/322

Causes helm to wait for deployment to complete before finishing. This might not be perfect error detection, but it's better than what it was doing before (which was nothing)

When there is a failure, print a slack message that looks like [THIS](https://app.slack.com/block-kit-builder/T04TS4HF3#%7B%22blocks%22:%5B%7B%22type%22:%22header%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22:alert:%20:fire:%20HELM%20DEPLOYMENT%20FAILURE%20:dumpster_fire:%20:alert:%22,%22emoji%22:true%7D%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22Sound%20the%20alarm,%20captain!%20This%20ship%20is%20going%20down!%5Cn%5Cnhelm%20encountered%20a%20failure%20while%20deploying%20this%20code.%5Cn%5Cn*release:*%20%3C%3C%20parameters.release%20%3E%3E%5Cn*chart:*%20%3C%3C%20parameters.chart%20%3E%3E/%3C%3C%20parameters.chart_version%20%3E%3E%5Cn*cluster:*%20%3C%3C%20parameters.cluster%20%3E%3E%22%7D%7D,%7B%22type%22:%22actions%22,%22elements%22:%5B%7B%22type%22:%22button%22,%22url%22:%22http://google.com%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22View%20on%20CircleCI%22%7D%7D%5D%7D%5D%7D)