### PR TITLE
an updated ubuntu AMI should not cause an ec2 instance to be recreated.

### DIFF
--- a/terraform/modules/lotus_dev_machines/main.tf
+++ b/terraform/modules/lotus_dev_machines/main.tf
@@ -11,25 +11,9 @@ locals {
   })
 }
 
-data "aws_ami" "ubuntu" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["099720109477"] # Canonical
-}
-
 resource "aws_instance" "mod" {
   for_each      = local.machines
-  ami           = each.value.ami != "" ? each.value.ami : data.aws_ami.ubuntu.id
+  ami           = each.value.ami != "" ? each.value.ami : var.ami
   instance_type = each.value.ec2_type
   key_name      = var.key_name
   root_block_device {

--- a/terraform/modules/lotus_dev_machines/variables.tf
+++ b/terraform/modules/lotus_dev_machines/variables.tf
@@ -14,3 +14,8 @@ variable "subnet_id" {
 variable "security_group_ids" {
   type = list(string)
 }
+
+variable "ami" {
+  type    = string
+  default = "ami-03f4121463e28151e"
+}


### PR DESCRIPTION
pin the default Ubuntu 20.04 AMI to prevent accidental recreation