### PR TITLE
add the fluxcd serviceaccount on other dcs

### DIFF
--- a/kubernetes/mainnet-ap-southeast-1-eks/rolebindings.yaml
+++ b/kubernetes/mainnet-ap-southeast-1-eks/rolebindings.yaml
@@ -78,3 +78,19 @@ roleRef:
   kind: Role
   name: ntwk-mainnet-disputer-exec
   apiGroup: rbac.authorization.k8s.io
+
+# fluxcd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  namespace: default
+  name: fluxcd-is-master
+subjects:
+  - kind: ServiceAccount
+    namespace: default
+    name: fluxcd
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/mainnet-ap-southeast-1-eks/serviceaccounts.yaml
+++ b/kubernetes/mainnet-ap-southeast-1-eks/serviceaccounts.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: fluxcd

--- a/kubernetes/mainnet-eu-central-1-eks/rolebindings.yaml
+++ b/kubernetes/mainnet-eu-central-1-eks/rolebindings.yaml
@@ -78,3 +78,19 @@ roleRef:
   kind: Role
   name: ntwk-mainnet-disputer-exec
   apiGroup: rbac.authorization.k8s.io
+
+# fluxcd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  namespace: default
+  name: fluxcd-is-master
+subjects:
+  - kind: ServiceAccount
+    namespace: default
+    name: fluxcd
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/mainnet-eu-central-1-eks/serviceaccounts.yaml
+++ b/kubernetes/mainnet-eu-central-1-eks/serviceaccounts.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: fluxcd

--- a/kubernetes/mainnet-us-east-1-eks/rolebindings.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/rolebindings.yaml
@@ -307,3 +307,19 @@ roleRef:
   kind: ClusterRole
   name: edit
   apiGroup: rbac.authorization.k8s.io
+
+# fluxcd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  namespace: default
+  name: fluxcd-is-master
+subjects:
+  - kind: ServiceAccount
+    namespace: default
+    name: fluxcd
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/mainnet-us-east-1-eks/serviceaccounts.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/serviceaccounts.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: fluxcd


### PR DESCRIPTION
Create a serviceaccount for flux on other DCs.

This does not mean flux is going to actually deploy anything yet, but the user will be there for when it's needed.