### PR TITLE
Configure dealbot bootstrap address to pando and set log level to info

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-dealbot/filecoin/dealbot/dealbot-0.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-dealbot/filecoin/dealbot/dealbot-0.yaml
@@ -27,6 +27,15 @@ controller:
     keySecret: dealbot-controller-key
     awsKeysSecret: dealbot-controller-aws-keys
     selfServeConfigSecret: dealbot-selfserve
+  env:
+    # Bootstrap with Pando service needed to propagate go-legs announcements over gossipsub.
+    # See: 
+    #  - http://pando-api.kencloud.com/pando/info
+    #  - https://github.com/kenlabs/pando
+    - name: DEALBOT_LIBP2P_BOOTSTRAP_ADDRINFO
+      value: "/ip4/52.14.211.248/tcp/9013/p2p/12D3KooWFC1cAXB7DJ71hafj8x6oLkGuATLMrqSauw4rp2fHFzoc"
+    - name: GOLOG_LOG_LEVEL
+      value: info
   resources:
     limits:
       cpu: 1000m

--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-nerpanet-dealbot/filecoin/dealbot/dealbot-0.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-nerpanet-dealbot/filecoin/dealbot/dealbot-0.yaml
@@ -27,6 +27,15 @@ controller:
     keySecret: dealbot-controller-key
     awsKeysSecret: dealbot-controller-aws-keys
     selfServeConfigSecret: dealbot-selfserve
+  env:
+    # Bootstrap with Pando service needed to propagate go-legs announcements over gossipsub.
+    # See: 
+    #  - http://pando-api.kencloud.com/pando/info
+    #  - https://github.com/kenlabs/pando
+    - name: DEALBOT_LIBP2P_BOOTSTRAP_ADDRINFO
+      value: "/ip4/52.14.211.248/tcp/9013/p2p/12D3KooWFC1cAXB7DJ71hafj8x6oLkGuATLMrqSauw4rp2fHFzoc"
+    - name: GOLOG_LOG_LEVEL
+      value: info
   resources:
     limits:
       cpu: 1000m


### PR DESCRIPTION
Configure the dealbot bootstrap addrinfo to Pando service on both
staging and production clusters. The bootrstrapping mechanism is needed
so that the go-lengs announcements are propagated to pando over
gossipsub.

While at it, set the log level of dealbot controller to `INFO`.

Relates to:
 - https://github.com/filecoin-project/dealbot/issues/342
 - http://pando-api.kencloud.com/pando/info
 - https://github.com/kenlabs/pando