### PR TITLE
Set some fixed resource limit and request for `storetheindex`

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
@@ -9,7 +9,13 @@ application:
     env: 
       - name: STORETHEINDEX_LISTEN_ADMIN
         value: /ip4/0.0.0.0/tcp/3002
-    resources: {}
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 3000Mi
+      requests:
+        cpu: 500m
+        memory: 2000Mi
     ports:
       - containerPort: 3000
         name: finder

--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
@@ -9,7 +9,13 @@ application:
     env: 
       - name: STORETHEINDEX_LISTEN_ADMIN
         value: /ip4/0.0.0.0/tcp/3002
-    resources: {}
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 3000Mi
+      requests:
+        cpu: 500m
+        memory: 2000Mi
     ports:
       - containerPort: 3000
         name: finder


### PR DESCRIPTION
Fix the resources used by `storetheindex` to make deployments more
reproducible, and make it easier to reason about the current resources
available to a pod.

This resource increase also relates to investigation into libp2p stream
memory limit reaching in production instance.