### PR TITLE
rename dev.cid.contact->staging.cid.contact

### DIFF
--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
@@ -119,7 +119,7 @@ application:
     enabled: true
     class: nginx
     httpRules:
-      - host: dev.cid.contact
+      - host: staging.cid.contact
         path: /
         servicePort: finder
   storage:


### PR DESCRIPTION
inbound from cloudflare has updated dns to staging. pointing to the same ELB, but we need the nginx layer to recognize the new host name as well.