### PR TITLE
Set loadbalancer type for dealbot controller libp2p service

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-dealbot/filecoin/dealbot/dealbot-0.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-dealbot/filecoin/dealbot/dealbot-0.yaml
@@ -23,6 +23,9 @@ controller:
     graphql:
       annotations:
         external-dns.alpha.kubernetes.io/hostname: dealbot-mainnet.mainnet-us-east-1.filops.net
+    libp2p:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
   secrets:
     keySecret: dealbot-controller-key
     awsKeysSecret: dealbot-controller-aws-keys

--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-nerpanet-dealbot/filecoin/dealbot/dealbot-0.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-nerpanet-dealbot/filecoin/dealbot/dealbot-0.yaml
@@ -23,6 +23,9 @@ controller:
     graphql:
       annotations:
         external-dns.alpha.kubernetes.io/hostname: dealbot-nerpanet.mainnet-us-east-2-dev.fildevops.net
+    libp2p:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
   secrets:
     keySecret: dealbot-controller-key
     awsKeysSecret: dealbot-controller-aws-keys


### PR DESCRIPTION
USe NLB as the type of loadbalacer for the libp2p node exposed on
dealbot controller added here:
 - https://github.com/filecoin-project/helm-charts/pull/124

Relates to:
 - https://github.com/filecoin-project/dealbot/issues/342