### PR TITLE
Specify readiness probe for storetheindex

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
@@ -16,6 +16,15 @@ application:
       requests:
         cpu: 500m
         memory: 2000Mi
+    readinessProbe:
+      httpGet:
+        port: finder
+        path: /health
+      initialDelaySeconds: 10
+      failureThreshold: 3
+      successThreshold: 1
+      timeoutSeconds: 5
+      periodSeconds: 10
     ports:
       - containerPort: 3000
         name: finder

--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
@@ -16,6 +16,15 @@ application:
       requests:
         cpu: 500m
         memory: 2000Mi
+    readinessProbe:
+      httpGet:
+        port: finder
+        path: /health
+      initialDelaySeconds: 10
+      failureThreshold: 3
+      successThreshold: 1
+      timeoutSeconds: 5
+      periodSeconds: 10
     ports:
       - containerPort: 3000
         name: finder


### PR DESCRIPTION
This is to reduce disruption in service while the indexer is
re-instantiating by reading disk which may take some time.

Builds on top of templated value here:
- https://github.com/filecoin-project/helm-charts/pull/139

Note that the PR linked above also fixes the templating of resources,
which is specified in values file. This means as part of merging this PR
the resources will now take effect, whereas before they had no impact on
the pods running.