### PR TITLE
Double storetheindex volume claims needed by one-off migration

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
@@ -156,7 +156,7 @@ volumeClaimTemplates:
         - ReadWriteOnce
       resources:
         requests:
-          storage: 5000Gi
+          storage: 10000Gi
 
 initContainers:
   - name: setupconfig

--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-storetheindex/filecoin/lotus-bundle/storetheindex-0.yaml
@@ -155,7 +155,7 @@ volumeClaimTemplates:
         - ReadWriteOnce
       resources:
         requests:
-          storage: 5000Gi
+          storage: 10000Gi
 
 initContainers:
   - name: setupconfig


### PR DESCRIPTION
To perform a one-off migration, double the PVC for storetheindex
statefulset in dev and prod.