### PR TITLE
Add storetheindex peer IDs to bootstrap protected peers

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/bootstrap-0.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-bootstrap/filecoin/lotus-fullnode/bootstrap-0.yaml
@@ -15,7 +15,11 @@ daemonConfig: |
 
     ProtectedPeers = [
       "12D3KooWF6pJZpWhcFRbVxAi9Py4PMPgQF5vXuw9zQp3J5yRxa7y",
-      "12D3KooWGdBAcWa7DNsMhuDHsom7cow3BtY7BcyvkDj9u4mM29hJ"
+      "12D3KooWGdBAcWa7DNsMhuDHsom7cow3BtY7BcyvkDj9u4mM29hJ",
+      "12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor",
+      "12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3",
+      "12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd",
+      "12D3KooWSQpUgBZwbNuMN3ctZjMesnoH9UDhwEXroxParXQCgurN"
     ]
   [Pubsub]
     IPColocationWhitelist = ["10.0.0.0/8"]


### PR DESCRIPTION
Add 4 new peer IDs that belong to `prod` and `dev` instances of
storetheindex running in storetheindex AWS account.

Peer ID to instance mapping:
* `prod`
  * `indexer-0`: `12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor`
  * `indexer-1`: `12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3`
* `dev`
  * `indexer-0`: `12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd`
  * `indexer-1`: `12D3KooWSQpUgBZwbNuMN3ctZjMesnoH9UDhwEXroxParXQCgurN`

See:
 - https://github.com/filecoin-project/storetheindex/tree/main/deploy/manifests/prod/us-east-2/tenant/storetheindex
 - https://github.com/filecoin-project/storetheindex/tree/main/deploy/manifests/dev/us-east-2/tenant/storetheindex