### PR TITLE
chore: Add io2 SC for high capacity volumes w low throughput

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/storage-classes/io2-high-capacity-low-throughput.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/storage-classes/io2-high-capacity-low-throughput.yaml
@@ -1,0 +1,14 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: io2-high-capacity-low-throughput
+  # annotations:
+  #   storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+parameters:
+  type: io2
+  iopsPerGB: "5"
+  allowAutoIOPSPerGBIncrease: "true" 


### PR DESCRIPTION
For lily instances which require large volumes but don't want to incur maximum number of IOPS with outsized IOPS/GiB ratios.

This follows the work applied in staging in https://github.com/filecoin-project/lotus-infra/pull/618.