### PR TITLE
grafana v8.5.2

### DIFF
--- a/kubernetes/helm/butterflynet-grafana/values.yaml
+++ b/kubernetes/helm/butterflynet-grafana/values.yaml
@@ -13,7 +13,7 @@ main_dashboard_slug: chain
 grafana:
   image:
     repository: grafana/grafana
-    tag: v8.2.6
+    tag: 8.5.2
   sidecar:
     datasources:
       enabled: true

--- a/kubernetes/helm/calibrationnet-grafana/values.yaml
+++ b/kubernetes/helm/calibrationnet-grafana/values.yaml
@@ -13,7 +13,7 @@ main_dashboard_slug: chain
 grafana:
   image:
     repository: grafana/grafana
-    tag: v8.2.6
+    tag: 8.5.2
   sidecar:
     datasources:
       enabled: true

--- a/kubernetes/helm/lotus-grafana/values.yaml
+++ b/kubernetes/helm/lotus-grafana/values.yaml
@@ -12,7 +12,7 @@ main_dashboard_slug: chain
 grafana:
   image:
     repository: grafana/grafana
-    tag: v8.2.6
+    tag: 8.5.2
   sidecar:
     datasources:
       enabled: true

--- a/kubernetes/helm/nerpanet-grafana/values.yaml
+++ b/kubernetes/helm/nerpanet-grafana/values.yaml
@@ -13,7 +13,7 @@ main_dashboard_slug: chain
 grafana:
   image:
     repository: grafana/grafana
-    tag: v8.2.6
+    tag: 8.5.2
   sidecar:
     datasources:
       enabled: true

--- a/kubernetes/helm/testnet-grafana/values.yaml
+++ b/kubernetes/helm/testnet-grafana/values.yaml
@@ -13,7 +13,7 @@ main_dashboard_slug: chain
 grafana:
   image:
     repository: grafana/grafana
-    tag: v8.2.6
+    tag: 8.5.2
   sidecar:
     datasources:
       enabled: true


### PR DESCRIPTION
Update images to v8.2.6

This switches us away from branded grafana instances to the upstream image.