### PR TITLE
chore: support NetworkBundle go var

### DIFF
--- a/scripts/build_binaries.bash
+++ b/scripts/build_binaries.bash
@@ -62,8 +62,13 @@ fi
 
 tags=$(join , ${gotags[@]})
 
+goflags=("-tags=$tags")
+if [ ! -z $NETWORK ]; then
+  goflags+=("-ldflags=-X=github.com/filecoin-project/lotus/build.NetworkBundle=${NETWORK}")
+fi
+
 envflags=()
-envflags+=(-e GOFLAGS="-tags=$tags")
+envflags+=(-e GOFLAGS="${goflags[@]}")
 
 ffiargs=()
 if [ "$BUILD_FFI" = true ]; then

--- a/scripts/build_containers.bash
+++ b/scripts/build_containers.bash
@@ -76,7 +76,7 @@ export DOCKER_BUILDKIT=1
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 pushd "$SCRIPTDIR/../docker"
 
-goflags=(--build-arg=GOFLAGS="-tags='$NETWORK'")
+goflags=(--build-arg=GOFLAGS="-tags='$NETWORK' -ldflags='-X=github.com/filecoin-project/lotus/build.NetworkBundle=$NETWORK'")
 
 ffiargs=()
 if [ "$BUILD_FFI" = true ]; then


### PR DESCRIPTION
Sets `build.NetworkBundle` to the correct network name to bundle fvm actors.