### PR TITLE
chore: build network binarines using make target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,7 +516,7 @@ jobs:
               "--src" "$LOTUS_SRC"
             )
             unset GOPATH
-            ./scripts/build_binaries.bash "${args[@]}"
+            ./scripts/build_binaries.bash "${args[@]}" -- "<< parameters.network >>"
       - run:
           name: Prepare binaries
           command: |

--- a/ansible/setup_fildev_network.bash
+++ b/ansible/setup_fildev_network.bash
@@ -157,7 +157,7 @@ additional_accounts=$(ansible -o -i $hostfile -b -m debug -a 'msg="{{ additional
 #scp ubuntu@192.168.1.240:/home/ubuntu/src/github.com/filecoin-project/lotus/lotus-shed .
 #popd
 
-../scripts/build_binaries.bash --src "$lotus_src" ${build_flags} --network $network_flag
+../scripts/build_binaries.bash --src "$lotus_src" ${build_flags} --network $network_flag -- ${network_flag}
 
 # runs all the roles
 ansible-playbook -i $hostfile lotus_devnet_provision.yml                                           \

--- a/ansible/upgrade_fildev_network_binaries.bash
+++ b/ansible/upgrade_fildev_network_binaries.bash
@@ -33,7 +33,7 @@ lotus_src="${src:-"$GOPATH/src/github.com/filecoin-project/lotus"}"
 network_flag=$(ansible -o -i $hostfile -b -m debug -a 'msg="{{ network_flag }}"' preminer0 | sed 's/.*=>//' | jq -r '.msg')
 
 
-../scripts/build_binaries.bash --src "$lotus_src" ${build_flags} --network $network_flag
+../scripts/build_binaries.bash --src "$lotus_src" ${build_flags} --network $network_flag -- $network_flag
 
 # runs all the roles
 ansible-playbook -i $hostfile lotus_update.yml \

--- a/scripts/build_binaries.bash
+++ b/scripts/build_binaries.bash
@@ -68,7 +68,7 @@ if [ ! -z $NETWORK ]; then
 fi
 
 envflags=()
-envflags+=(-e GOFLAGS="${goflags[@]}")
+# envflags+=(-e GOFLAGS="${goflags[@]}")
 
 ffiargs=()
 if [ "$BUILD_FFI" = true ]; then


### PR DESCRIPTION
This was originally a work around, but due to https://github.com/filecoin-project/lotus/issues/8684, the only way to build networks "correctly" is using the make target.

There is work to update the make file, which when the PR opens up, we will need to engage with to make sure it works for us and make any changes required.