### PR TITLE
increase fullnode datastore volume size and change class

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/fullnode/fullnode-0/fullnode-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/fullnode/fullnode-0/fullnode-values.yaml
@@ -6,3 +6,7 @@ secrets:
   jwt:
     enabled: true
     secretName: fullnode-0-jwt-secrets
+persistence:
+  datastore:
+    size: "32000Gi"
+    storageClassName: "io2-high-capacity-low-throughput"


### PR DESCRIPTION
increase volume size to 32TiB and change volume class to an io2 class to support it
in general, we're hoping to be able to import a snapshot from the last checkpoint before our legacy fullnodes reached capacity