### PR TITLE
fixes bug in io2 provisioner type

### DIFF
--- a/kubernetes/gitops/base/storage/io2-high-capacity-low-throughput.yaml
+++ b/kubernetes/gitops/base/storage/io2-high-capacity-low-throughput.yaml
@@ -4,11 +4,11 @@ metadata:
   name: io2-high-capacity-low-throughput
   # annotations:
   #   storageclass.kubernetes.io/is-default-class: "true"
-provisioner: ebs.csi.aws.com
+provisioner: kubernetes.io/aws-ebs
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 allowVolumeExpansion: true
 parameters:
   type: io2
   iopsPerGB: "5"
-  allowAutoIOPSPerGBIncrease: "true" 
+  allowAutoIOPSPerGBIncrease: "true"

--- a/kubernetes/gitops/base/storage/io2-low-throughput-storage-class.yaml
+++ b/kubernetes/gitops/base/storage/io2-low-throughput-storage-class.yaml
@@ -4,11 +4,11 @@ metadata:
   name: io2-low-throughput
   # annotations:
   #   storageclass.kubernetes.io/is-default-class: "true"
-provisioner: ebs.csi.aws.com
+provisioner: kubernetes.io/aws-ebs
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 allowVolumeExpansion: true
 parameters:
   type: io2
   iopsPerGB: "20"
-  allowAutoIOPSPerGBIncrease: "true" 
+  allowAutoIOPSPerGBIncrease: "true"

--- a/kubernetes/gitops/base/storage/io2-storage-class.yaml
+++ b/kubernetes/gitops/base/storage/io2-storage-class.yaml
@@ -4,11 +4,11 @@ metadata:
   name: io2
   # annotations:
   #   storageclass.kubernetes.io/is-default-class: "true"
-provisioner: ebs.csi.aws.com
+provisioner: kubernetes.io/aws-ebs
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 allowVolumeExpansion: true
 parameters:
   type: io2
   iopsPerGB: "500"
-  allowAutoIOPSPerGBIncrease: "true" 
+  allowAutoIOPSPerGBIncrease: "true"


### PR DESCRIPTION
testing io2 storageclasses resulted in problems attaching volumes to instances, due to the incorrect provisioner being set.
this volumeclass is intended for lotus fullnodes only, whose volumes need to be created from EBS snapshots manually.
as a result, the provisioner should be kubernetes.io/aws-ebs
