### PR TITLE
don't import chain snapshot

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/fullnode/fullnode-0/fullnode-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/fullnode/fullnode-0/fullnode-values.yaml
@@ -10,3 +10,5 @@ persistence:
   datastore:
     size: "32000Gi"
     storageClassName: "io2-high-capacity-low-throughput"
+importSnapshot:
+  enabled: false


### PR DESCRIPTION
fullnode-0 is using a manually provisioned volume created from an EBS snapshot capturing our last checkpoint of full history datastore