### PR TITLE
Update golang from 1.17.9 to 1.18.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,8 +403,8 @@ jobs:
       - run:
           name: install golang
           command: |
-            curl -LOs https://golang.org/dl/go1.17.9.linux-amd64.tar.gz
-            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.17.9.linux-amd64.tar.gz
+            curl -LOs https://golang.org/dl/go1.18.1.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz
       # - go/install:
       #   # ensure that the cache key matches the go version to clean up lingering source files
       #   # that may not be compatable across versions. Golang recommend to always uninstall the
@@ -674,8 +674,8 @@ jobs:
       - run:
           name: install golang
           command: |
-            curl -LOs https://golang.org/dl/go1.17.9.linux-amd64.tar.gz
-            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.17.9.linux-amd64.tar.gz
+            curl -LOs https://golang.org/dl/go1.18.1.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz
       # - go/install:
       #     version: 1.16.5
       #     cache-key: v1.16.5

--- a/docker/Dockerfile.binarybuilder
+++ b/docker/Dockerfile.binarybuilder
@@ -1,4 +1,4 @@
-FROM golang:1.17.9-stretch AS builder
+FROM golang:1.18.1-stretch AS builder
 MAINTAINER Filecoin Development Team
 
 RUN apt-get update && apt-get install -y ca-certificates build-essential clang jq ocl-icd-opencl-dev ocl-icd-libopencl1 libhwloc-dev

--- a/docker/Dockerfile.lotus
+++ b/docker/Dockerfile.lotus
@@ -4,7 +4,7 @@ ARG BUILDER_BASE=builder-local
 # builder-base
 # ---------------------
 
-FROM golang:1.17.9 AS builder-deps
+FROM golang:1.18.1 AS builder-deps
 MAINTAINER Lotus Development Team
 
 RUN apt-get update && apt-get install -y ca-certificates build-essential clang ocl-icd-opencl-dev ocl-icd-libopencl1 jq libhwloc-dev


### PR DESCRIPTION
Lotus now requires v1.18.1. I'm updating this so we can upgrade to butterflynet to test nv17