### PR TITLE
chore: update snapshot lotus nodes to v1.18.0-rc2 for v17

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-calibnet-snapshot/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-calibnet-snapshot/filecoin/lotus-fullnode/base.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: calibnet-v1.16.0
+  tag: calibnet-v1.18.0-rc2
 
 prometheusOperatorServiceMonitor: true
 

--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-calibnet-snapshot/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-calibnet-snapshot/filecoin/lotus-fullnode/base.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: calibnet-v1.17.1
+  tag: calibnet-v1.18.0-rc2
 
 prometheusOperatorServiceMonitor: true
 


### PR DESCRIPTION
closes filecoin-project/lotus-infra-archive#109