### PR TITLE
chore: update verified registry addr for network reset

### DIFF
--- a/ansible/inventories/calibration.fildev.network/group_vars/all/vars.yml
+++ b/ansible/inventories/calibration.fildev.network/group_vars/all/vars.yml
@@ -4,7 +4,7 @@ network_name: calibrationnet
 network_flag: calibnet
 faucet_initial_balance: "250000000000000000000000000"
 miners_initial_balance: "75000000000000000000000"
-verifreg_rootkey: "t1dtu5wnljecifn4iaeatmnsfrvc5skgkitwauocq"
+verifreg_rootkey: "t1zo7ub42i3s5cutljzjuqwnltt4xxm4y4f7l5s2i"
 
 additional_account_balance: {}
 


### PR DESCRIPTION
The signer key is located in the `filecoin dev` vault under key `secp256k1-t1zo7ub42i3s5cutljzjuqwnltt4xxm4y4f7l5s2i.keyinfo`.