### PR TITLE
Revert "chore: set butterfly proof version to v27.1"

### DIFF
--- a/ansible/inventories/butterfly.fildev.network/group_vars/all/vars.yml
+++ b/ansible/inventories/butterfly.fildev.network/group_vars/all/vars.yml
@@ -31,7 +31,7 @@ sentinel_telegraf_outputs_postgresql_conn: "{{ vault_timescale_conn }}"
 lotus_ipfs_gateway: https://proofs.filecoin.io/ipfs/
 lotus_user: "fc"
 lotus_user_uid: "532"
-proof_version: v27.1
+proof_version: v28
 proof_type: fake
 sector_size: 512MiB
 filebeat_additional_processors: |


### PR DESCRIPTION
Reverts filecoin-project/lotus-infra#904

This PR helped us confirm that the calibnet reset flow would work (using butterfly as a test). I'm pretty sure we'll want to revert this to get back to resetting butterfly from genesis v16.