### PR TITLE
bump up the memory for bootstrap and Disputer pods to 48G from 32G

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/bootstrap/values.yaml
@@ -5,7 +5,7 @@ prometheusOperatorServiceMonitor: true
 
 resources:
   requests:
-    memory: 32Gi
+    memory: 48Gi
     cpu: 6
 
 importSnapshot:

--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/disputer/values.yaml
@@ -5,8 +5,8 @@ prometheusOperatorServiceMonitor: true
 
 resources:
   requests:
-    memory: 32Gi
-    cpu: 4
+    memory: 48Gi
+    cpu: 6 
   limits:
     memory: 48Gi
     cpu: 6


### PR DESCRIPTION
Updated the values.yaml files in the base for disputers and bootstrap to 48G for memory allocation 