### PR TITLE
Adding memory limits to Bootstrap and Disputer Nodes

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/bootstrap/values.yaml
@@ -7,6 +7,10 @@ resources:
   requests:
     memory: 48Gi
     cpu: 6
+  limits:
+    memory: 54Gi
+    cpu: 6
+
 
 importSnapshot:
   enabled: true

--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/disputer/values.yaml
@@ -8,7 +8,7 @@ resources:
     memory: 48Gi
     cpu: 6 
   limits:
-    memory: 48Gi
+    memory: 54Gi
     cpu: 6
 
 importSnapshot:


### PR DESCRIPTION
Add Limit Constrains to both bootstrap and Disputers, so that they will be scheduled on r5.2xlarge machines only. 
