### PR TITLE
reduce resource consumption for butterflynet and calibnet

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/butterflynet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/butterflynet/base/bootstrap/values.yaml
@@ -5,11 +5,11 @@ prometheusOperatorServiceMonitor: true
 
 resources:
   requests:
-    memory: 96Gi
-    cpu: 8
+    memory: 4Gi
+    cpu: 4
   limits:
-    memory: 112Gi
-    cpu: 12
+    memory: 6Gi
+    cpu: 6
 
 importSnapshot:
   enabled: false
@@ -42,4 +42,4 @@ additionalLabels:
 persistence:
   datastore:
     enabled: true
-    size: "8000Gi"
+    size: "50Gi"

--- a/kubernetes/gitops/dev/us-east-2/butterflynet/base/disputer/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/butterflynet/base/disputer/values.yaml
@@ -5,11 +5,11 @@ prometheusOperatorServiceMonitor: true
 
 resources:
   requests:
-    memory: 96Gi
-    cpu: 8
+    memory: 4Gi
+    cpu: 4
   limits:
-    memory: 112Gi
-    cpu: 12
+    memory: 6Gi
+    cpu: 6
 
 importSnapshot:
   enabled: true

--- a/kubernetes/gitops/dev/us-east-2/butterflynet/base/fullnode/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/butterflynet/base/fullnode/values.yaml
@@ -5,11 +5,11 @@ prometheusOperatorServiceMonitor: true
 
 resources:
   requests:
-    memory: 96Gi
-    cpu: 8
+    memory: 4Gi
+    cpu: 4
   limits:
-    memory: 112Gi
-    cpu: 12
+    memory: 6Gi
+    cpu: 6
 
 importSnapshot:
   enabled: false
@@ -41,4 +41,4 @@ additionalLabels:
 persistence:
   datastore:
     enabled: true
-    size: "8000Gi"
+    size: "50Gi"

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/base/bootstrap/values.yaml
@@ -5,11 +5,11 @@ prometheusOperatorServiceMonitor: true
 
 resources:
   requests:
-    memory: 96Gi
-    cpu: 10
+    memory: 8Gi
+    cpu: 4
   limits:
-    memory: 112Gi
-    cpu: 12
+    memory: 12Gi
+    cpu: 6
 
 importSnapshot:
   enabled: false
@@ -41,4 +41,4 @@ additionalLabels:
 persistence:
   datastore:
     enabled: true
-    size: "8000Gi"
+    size: "500Gi"

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/base/disputer/values.yaml
@@ -5,12 +5,11 @@ prometheusOperatorServiceMonitor: true
 
 resources:
   requests:
-    memory: 96Gi
-    cpu: 8
+    memory: 8Gi
+    cpu: 4
   limits:
-    memory: 112Gi
-    cpu: 12
-
+    memory: 12Gi
+    cpu: 6
 importSnapshot:
   enabled: false
 
@@ -41,4 +40,4 @@ additionalLabels:
 persistence:
   datastore:
     enabled: true
-    size: "8000Gi"
+    size: "500Gi"

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/base/fullnode/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/base/fullnode/values.yaml
@@ -5,11 +5,11 @@ prometheusOperatorServiceMonitor: true
 
 resources:
   requests:
-    memory: 96Gi
-    cpu: 8
+    memory: 8Gi
+    cpu: 4
   limits:
-    memory: 112Gi
-    cpu: 12
+    memory: 12Gi
+    cpu: 6
 
 importSnapshot:
   enabled: false
@@ -41,4 +41,4 @@ additionalLabels:
 persistence:
   datastore:
     enabled: true
-    size: "8000Gi"
+    size: "500Gi"


### PR DESCRIPTION
these are based from https://protocollabs.grafana.net/d/B0ongPFGk/lotus-service?orgId=1&var-datasource=Thanos&var-cluster=fil-infra-us-east-2-dev-v1&var-namespace=ntwk-calibrationnet&var-service=node-0-fullnode-lotus-daemon&var-pod=node-0-fullnode-lotus-0&var-api_export=All with a little bit of buffer.

these numbers can be dialed in further, but starting with this immediately to unblock scheduling contention in this kubernetes cluster, and reduce costs