### PR TITLE
chore: update snapshots nodes to v1.18.0

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-snapshot/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-snapshot/filecoin/lotus-fullnode/base.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: mainnet-v1.16.0
+  tag: mainnet-v1.18.0
 
 prometheusOperatorServiceMonitor: true
 

--- a/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-snapshot/filecoin/lotus-fullnode/base.yaml
+++ b/kubernetes/mainnet-us-east-2-dev-eks/helm/ntwk-mainnet-snapshot/filecoin/lotus-fullnode/base.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: mainnet-v1.16.0
+  tag: mainnet-v1.18.0
 
 prometheusOperatorServiceMonitor: true
 


### PR DESCRIPTION
closes filecoin-project/lotus-infra-archive#72