### PR TITLE
fix: correct disputer-0 wallet

### DIFF
--- a/kubernetes/gitops/prod/eu-central-1/mainnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/base/disputer/values.yaml
@@ -14,10 +14,6 @@ resources:
 importSnapshot:
   enabled: true
   strategy: url
-  claimName: chain-exports
-  network: mainnet
-  exportRelease: finality-stateroots
-  exitCodeOnMissing: 1
 
 persistence:
   datastore:
@@ -34,7 +30,7 @@ daemonEnvs:
 
 disputer:
   enabled: true
-  walletAddr: f1xfr2bh23j2s7rmvwxx4linma4luxqxpyrfax5da
+  walletAddr: f1vkujr5ecab5t6nkstqukbt2vv2ams55pwl3crki
   # maxFee:
   env:
     - name: GOLOG_LOG_FMT


### PR DESCRIPTION
The disputer sidecar of disputer-0 is crashlooping due to an misconfigured wallet address