### PR TITLE
update chart version on bootstrappersand disputers in eu and ap

### DIFF
--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/bootstrap/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/bootstrap/fullnode-helmrelease-patch.yaml
@@ -7,4 +7,4 @@ spec:
     timeout: "90m"
   chart:
     spec:
-      version: 0.3.4
+      version: 0.3.5

--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/disputer/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/disputer/fullnode-helmrelease-patch.yaml
@@ -7,4 +7,4 @@ spec:
     timeout: "90m"
   chart:
     spec:
-      version: 0.3.4
+      version: 0.3.5

--- a/kubernetes/gitops/prod/eu-central-1/mainnet/base/bootstrap/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/base/bootstrap/fullnode-helmrelease-patch.yaml
@@ -7,4 +7,4 @@ spec:
     timeout: "90m"
   chart:
     spec:
-      version: 0.3.4
+      version: 0.3.5

--- a/kubernetes/gitops/prod/eu-central-1/mainnet/base/disputer/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/base/disputer/fullnode-helmrelease-patch.yaml
@@ -7,4 +7,4 @@ spec:
     timeout: "90m"
   chart:
     spec:
-      version: 0.3.4
+      version: 0.3.5


### PR DESCRIPTION
need to upgrade to the latest lotus-fullnode helm chart version to use the latest snapshots