### PR TITLE
chore: enable easy reset for bootstrap and disputer

### DIFF
--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/bootstrap/values.yaml
@@ -16,7 +16,7 @@ persistence:
   datastore:
     enabled: true
     easyReset: true
-    size: "2000Gi"
+    size: "16000Gi"
     storageClassName: "gp2"
 
 daemonConfig: |
@@ -48,8 +48,3 @@ daemonEnvs:
 
 additionalLabels:
   network: mainnet
-
-persistence:
-  datastore:
-    enabled: true
-    size: "16000Gi"

--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/disputer/values.yaml
@@ -14,16 +14,12 @@ resources:
 importSnapshot:
   enabled: true
   strategy: url
-  claimName: chain-exports
-  network: mainnet
-  exportRelease: finality-stateroots
-  exitCodeOnMissing: 1
 
 persistence:
   datastore:
     enabled: true
     easyReset: true
-    size: "2000Gi"
+    size: "16000Gi"
     storageClassName: "gp2"
 
 daemonEnvs:
@@ -42,8 +38,3 @@ disputer:
 
 additionalLabels:
   network: mainnet
-
-persistence:
-  datastore:
-    enabled: true
-    size: "16000Gi"

--- a/kubernetes/gitops/prod/eu-central-1/mainnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/base/bootstrap/values.yaml
@@ -16,7 +16,7 @@ persistence:
   datastore:
     enabled: true
     easyReset: true
-    size: "2000Gi"
+    size: "16000Gi"
     storageClassName: "gp2"
 
 daemonConfig: |
@@ -48,8 +48,3 @@ daemonEnvs:
 
 additionalLabels:
   network: mainnet
-
-persistence:
-  datastore:
-    enabled: true
-    size: "16000Gi"

--- a/kubernetes/gitops/prod/eu-central-1/mainnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/base/disputer/values.yaml
@@ -19,7 +19,7 @@ persistence:
   datastore:
     enabled: true
     easyReset: true
-    size: "2000Gi"
+    size: "16000Gi"
     storageClassName: "gp2"
 
 daemonEnvs:
@@ -38,8 +38,3 @@ disputer:
 
 additionalLabels:
   network: mainnet
-
-persistence:
-  datastore:
-    enabled: true
-    size: "16000Gi"

--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/bootstrap/values.yaml
@@ -16,7 +16,7 @@ persistence:
   datastore:
     enabled: true
     easyReset: true
-    size: "2000Gi"
+    size: "16000Gi"
     storageClassName: "gp2"
 
 daemonConfig: |
@@ -48,8 +48,3 @@ daemonEnvs:
 
 additionalLabels:
   network: mainnet
-
-persistence:
-  datastore:
-    enabled: true
-    size: "16000Gi"

--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/disputer/values.yaml
@@ -14,16 +14,12 @@ resources:
 importSnapshot:
   enabled: true
   strategy: url
-  claimName: chain-exports
-  network: mainnet
-  exportRelease: finality-stateroots
-  exitCodeOnMissing: 1
 
 persistence:
   datastore:
     enabled: true
     easyReset: true
-    size: "2000Gi"
+    size: "16000Gi"
     storageClassName: "gp2"
 
 daemonEnvs:
@@ -42,8 +38,3 @@ disputer:
 
 additionalLabels:
   network: mainnet
-
-persistence:
-  datastore:
-    enabled: true
-    size: "16000Gi"


### PR DESCRIPTION
duplicate persistence blocks resulted in the easyReset feature being disabled