### PR TITLE
increase timeout in us-east-1

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
@@ -4,4 +4,6 @@ metadata:
   name: gateway
 spec:
   install:
-    timeout: "90m"
+    timeout: 120m
+  upgrade:
+    timeout: 120m


### PR DESCRIPTION
This applies the same thing as https://github.com/filecoin-project/lotus-infra/pull/993 but targets us-east-1 only. 