### PR TITLE
increase Install and Upgrade timeout Values

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/disputer/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/disputer/fullnode-helmrelease-patch.yaml
@@ -4,7 +4,9 @@ metadata:
   name: fullnode
 spec:
   install:
-    timeout: "90m"
+    timeout: "120m"
+  upgrade:
+    timeout: "120m"
   chart:
     spec:
       version: 0.3.4


### PR DESCRIPTION
The is increasing the the timeout value for the `installs` and the `upgrades` of the disputer pods. Since the pods are ending up in a crash loop due to suspected timeout 