### PR TITLE
schedule lotus nodes on the correct ec2 types

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/butterflynet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/butterflynet/base/bootstrap/values.yaml
@@ -43,3 +43,6 @@ persistence:
   datastore:
     enabled: true
     size: "50Gi"
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/dev/us-east-2/butterflynet/base/fullnode/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/butterflynet/base/fullnode/values.yaml
@@ -42,3 +42,6 @@ persistence:
   datastore:
     enabled: true
     size: "50Gi"
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/base/bootstrap/values.yaml
@@ -42,3 +42,6 @@ persistence:
   datastore:
     enabled: true
     size: "500Gi"
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/base/disputer/values.yaml
@@ -41,3 +41,6 @@ persistence:
   datastore:
     enabled: true
     size: "500Gi"
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/base/fullnode/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/base/fullnode/values.yaml
@@ -42,3 +42,6 @@ persistence:
   datastore:
     enabled: true
     size: "500Gi"
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/bootstrap/values.yaml
@@ -39,8 +39,8 @@ daemonEnvs:
   - name: GOLOG_LOG_FMT
     value: json
 
-# nodeSelector:
-#   "fil-infra.protocol.ai/node-type": "lotus-standard"
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"
 
 additionalLabels:
   network: mainnet

--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/disputer/values.yaml
@@ -6,7 +6,7 @@ prometheusOperatorServiceMonitor: true
 resources:
   requests:
     memory: 48Gi
-    cpu: 6 
+    cpu: 6
   limits:
     memory: 54Gi
     cpu: 6
@@ -42,3 +42,6 @@ disputer:
 
 additionalLabels:
   network: mainnet
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/fullnode/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/fullnode/values.yaml
@@ -43,3 +43,6 @@ persistence:
   datastore:
     enabled: true
     size: "16000Gi"
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5b.8xlarge"


### PR DESCRIPTION
use nodeSelectors to ensure scheduling on the desired ec2 types. bootstrappers and disputers should run on r5.2xlarges full history nodes should run on r5b.2xlarges