### PR TITLE
Remove fullnode-2 from kustomization file

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/kustomization.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/kustomization.yaml
@@ -7,4 +7,3 @@ namespace: mainnet
 resources:
 - fullnode-0
 - fullnode-1
-- fullnode-2


### PR DESCRIPTION
The files associated with fullnode-2 were removed previously in https://github.com/filecoin-project/lotus-infra/pull/1014