### PR TITLE
resize fullnode datastore to 32TiB

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/fullnode/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/fullnode/values.yaml
@@ -42,7 +42,8 @@ additionalLabels:
 persistence:
   datastore:
     enabled: true
-    size: "16000Gi"
+    size: "32000Gi"
+    storageClassName: "io2-high-capacity-low-throughput"
 
 nodeSelector:
   "node.kubernetes.io/instance-type": "r5b.8xlarge"


### PR DESCRIPTION
this will match expectations with the PVC and PV already existing in the fil-infra-us-east-2-dev-v2