### PR TITLE
fix: specify resources for stats dashboard

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/butterflynet/tenant/stats-dashboard/kustomization.yaml
+++ b/kubernetes/gitops/dev/us-east-2/butterflynet/tenant/stats-dashboard/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 
 resources:
 - ../../../../../base/applications/stats-dashboard
+- datasource-secrets.yaml
+- chainstats-dashboard.yaml
 
 patchesStrategicMerge:
   - stats-dashboard-helmrelease-patch.yaml

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/stats-dashboard/kustomization.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/stats-dashboard/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 
 resources:
 - ../../../../../base/applications/stats-dashboard
+- datasource-secrets.yaml
+- chainstats-dashboard.yaml
 
 patchesStrategicMerge:
   - stats-dashboard-helmrelease-patch.yaml


### PR DESCRIPTION
When creating raw k8s resources it looks like they need to be define in the resource list of a Kustomization resource. I'm drawing this from how https://github.com/filecoin-project/lotus-infra/blob/master/kubernetes/gitops/dev/us-east-2/calibrationnet/cluster/kustomization.yaml is configured.