### PR TITLE
chore: set load balancer cert for stats dashboard

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/butterflynet/tenant/stats-dashboard/stats-dashboard-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/butterflynet/tenant/stats-dashboard/stats-dashboard-values.yaml
@@ -65,7 +65,7 @@ grafana:
     port: 443
     portName: https
     annotations:
-      # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: #########
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-2:759815798766:certificate/5ffc960e-03cb-4dcc-a6e1-d80d5c953746
       external-dns.alpha.kubernetes.io/hostname: stats-staging.butterflynet.filops.net
       external-dns.alpha.kubernetes.io/alias: "true"
       external-dns.alpha.kubernetes.io/ttl: "60"

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/stats-dashboard/stats-dashboard-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/stats-dashboard/stats-dashboard-values.yaml
@@ -65,7 +65,7 @@ grafana:
     port: 443
     portName: https
     annotations:
-      # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: #########
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-2:759815798766:certificate/3ec544f8-ec91-47d7-839d-6871c1338569
       external-dns.alpha.kubernetes.io/hostname: stats-staging.calibrationnet.filops.net
       external-dns.alpha.kubernetes.io/alias: "true"
       external-dns.alpha.kubernetes.io/ttl: "60"


### PR DESCRIPTION
These were manually created through the aws console, later it would be nice if this could be handled by gitops somehow. However, this flow of manually creating the certs works better for the currently deployed production dashboards

- stats.filecoin.io
- stats.butterfly.fildev.network
- stats.calibration.fildev.network