### PR TITLE
upgrades filecoin-chain-archiver docker image and change cronjob frequency

### DIFF
--- a/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-snapshot/filecoin/filecoin-chain-archiver/base.yaml
+++ b/kubernetes/mainnet-us-east-1-eks/helm/ntwk-mainnet-snapshot/filecoin/filecoin-chain-archiver/base.yaml
@@ -61,8 +61,8 @@ nodelocker:
 
 podResets:
   - pod: lotus-a-lotus-0
-    schedule: "0 0 * * 1"
+    schedule: "0 0 * * 1,4"
   - pod: lotus-b-lotus-0
-    schedule: "0 0 * * 3"
+    schedule: "0 0 * * 2,5"
   - pod: lotus-c-lotus-0
-    schedule: "0 0 * * 5"
+    schedule: "0 0 * * 3,6"


### PR DESCRIPTION
* the binary in this docker image has a new command required by the automated datastore reset cronjob.
* make cronjobs run every 3 days