### PR TITLE
rename the application base common config map properly

### DIFF
--- a/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/kustomization.yaml
+++ b/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 configMapGenerator:
 - files:
   - values.yaml=lighweight-snapshot-chain-archiver.yaml
-  name: lighweight-snapshot-chain-archiver
+  name: lighweight-snapshot-chain-archiver-common-values
 
 configurations:
   - kustomizeconfig.yaml


### PR DESCRIPTION
helm release complains about: could not find ConfigMap 'ntwk-calibrationnet/lighweight-snapshot-chain-archiver-common-values' this change should fix it