### PR TITLE
reduce full archives nodes from 2 to 1, disable snapshot imports

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/fullnode-0/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/fullnode-0/fullnode-values.yaml
@@ -6,3 +6,6 @@ secrets:
   jwt:
     enabled: true
     secretName: fullnode-0-jwt-secrets
+
+importSnapshot:
+  enabled: false

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/fullnode-1/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/fullnode-1/fullnode-values.yaml
@@ -8,8 +8,4 @@ secrets:
     secretName: fullnode-1-jwt-secrets
 
 importSnapshot:
-  enabled: true
-  claimName: chain-exports
-  network: mainnet
-  exportRelease: export-full-archive
-  exitCodeOnMissing: 0
+  enabled: false

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/kustomization.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/kustomization.yaml
@@ -6,4 +6,4 @@ namespace: mainnet
 
 resources:
 - fullnode-0
-- fullnode-1
+# - fullnode-1


### PR DESCRIPTION
* remove fullnode-1 to keep expenses down - 32TiB volumes and t2.8xlarges are expensive.
* prevent snapshot imports, because we're using volumes restored from EBS snapshots already