### PR TITLE
temporarily disable lightweight-snapshot infra

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/kustomization.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/kustomization.yaml
@@ -8,6 +8,6 @@ resources:
 - fullnode
 - bootstrap
 - stats-dashboard
-- lightweight-snapshot-node
-- lightweight-snapshot-chain-archiver
+# - lightweight-snapshot-node
+# - lightweight-snapshot-chain-archiver
 # - disputer

--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/kustomization.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
 - bootstrap
 - disputer
 - gateway
-- lightweight-snapshot-node
-- lightweight-snapshot-chain-archiver
+# - lightweight-snapshot-node
+# - lightweight-snapshot-chain-archiver

--- a/kubernetes/gitops/prod/us-east-1/calibrationnet/tenant/kustomization.yaml
+++ b/kubernetes/gitops/prod/us-east-1/calibrationnet/tenant/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
 - ../../../../base/applications/common
 - fullnode
 - bootstrap
-- lightweight-snapshot-node
+# - lightweight-snapshot-node
 - stats-dashboard

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/kustomization.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 - bootstrap
 - disputer
 - gateway
-- lightweight-snapshot-node
+#- lightweight-snapshot-node


### PR DESCRIPTION
shut this down over the holidays, as it's not being used or actively developed on