### PR TITLE
put nodeSelectors in tenant directories

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/disputer/disputer-0/fullnode-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/disputer/disputer-0/fullnode-values.yaml
@@ -10,3 +10,6 @@ secrets:
     secretName: wallet-disputer-0
 loadBalancer:
   enabled: false
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/disputer/disputer-0/fullnode-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/disputer/disputer-0/fullnode-values.yaml
@@ -10,3 +10,6 @@ secrets:
     secretName: disputer-node-0-wallet
 loadBalancer:
   enabled: false
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/gateway/staging-api-chain-love/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/gateway/staging-api-chain-love/values.yaml
@@ -67,3 +67,6 @@ prometheus:
   serviceMonitor: true
   path: /debug/metrics
   port: lotus-gw
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/disputer/disputer-0/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/disputer/disputer-0/fullnode-values.yaml
@@ -10,3 +10,6 @@ secrets:
     secretName: disputer-node-0-wallet
 loadBalancer:
   enabled: false
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/fullnode-0/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/fullnode/fullnode-0/fullnode-values.yaml
@@ -9,3 +9,6 @@ secrets:
 
 importSnapshot:
   enabled: false
+
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5b.8xlarge"

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/gateway/api-chain-love/values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/gateway/api-chain-love/values.yaml
@@ -1,0 +1,2 @@
+nodeSelector:
+  "node.kubernetes.io/instance-type": "r5.2xlarge"


### PR DESCRIPTION
for some reason, nodeSelector inheritance from the 'base' directories aren't working. add nodeSelectors in tenant directories directly to ensure proper scheduling