### PR TITLE
update chain archiver config for new lotus pod names

### DIFF
--- a/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver.yaml
+++ b/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver.yaml
@@ -12,9 +12,9 @@ indexResolver:
 
 snapshots:
   nodes:
-  - /dns/lightweight-snapshot-node-0-fullnode-lotus-daemon/tcp/1234
-  - /dns/lightweight-snapshot-node-1-fullnode-lotus-daemon/tcp/1234
-  - /dns/lightweight-snapshot-node-2-fullnode-lotus-daemon/tcp/1234
+  - /dns/lws-node-0-fullnode-lotus-daemon/tcp/1234
+  - /dns/lws-node-1-fullnode-lotus-daemon/tcp/1234
+  - /dns/lws-node-0-fullnode-lotus-daemon/tcp/1234
 
   schedule: "0 */2 * * *"
 
@@ -39,9 +39,9 @@ nodelocker:
     value: "json"
 
 podResets:
-  - pod: lightweight-snapshot-node-0-fullnode-lotus-0
+  - pod: lws-node-0-fullnode-lotus-0
     schedule: "0 0 * * 1,4"
-  - pod: lightweight-snapshot-node-1-fullnode-lotus-0
+  - pod: lws-node-1-fullnode-lotus-0
     schedule: "0 0 * * 2,5"
-  - pod: lightweight-snapshot-node-2-fullnode-lotus-0
+  - pod: lws-node-2-fullnode-lotus-0
     schedule: "0 0 * * 3,6"


### PR DESCRIPTION
lotus pod and service names were shortened, and this change updates the multiaddr and podReset names accordingly