### PR TITLE
updates filecoin-chain-archiver helm chart to 1.0.2

### DIFF
--- a/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/helmrelease.yaml
+++ b/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
         apiVersion: source.toolkit.fluxcd.io/v1beta1
         kind: HelmRepository
         name: filecoin-project-charts
-      version: 1.0.1
+      version: 1.0.2
   interval: 1m0s
   # The values are merged in the order given, with the later values overwriting earlier. These values always have a lower priority
   valuesFrom:


### PR DESCRIPTION
this updates to a new version of the chart that truncates the cronjob name if necessary, and in general has a shorter default name. without this upgrade, deployments in our gitops clusters fail