### PR TITLE
upgrades lotus-snapshot-chain-archiver for naming fix

### DIFF
--- a/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/helmrelease.yaml
+++ b/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
         apiVersion: source.toolkit.fluxcd.io/v1beta1
         kind: HelmRepository
         name: filecoin-project-charts
-      version: 1.0.2
+      version: 1.0.3
   interval: 1m0s
   # The values are merged in the order given, with the later values overwriting earlier. These values always have a lower priority
   valuesFrom:


### PR DESCRIPTION
this version of the helm chart includes a trimPrefix to remove leading '-'s caused by inverse truncation