### PR TITLE
Fix snapshot uploads to r2

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -12,6 +12,7 @@ indexResolver:
   loadBalancer:
     enabled: false
 
+snapshots:
   uploads:
     enabled: true
     bucket: "filecoin-snapshots-mainnet-staging"

--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -12,6 +12,7 @@ indexResolver:
   loadBalancer:
     enabled: false
 
+snapshots:
   uploads:
     enabled: true
     bucket: "filecoin-snapshots-mainnet-staging"


### PR DESCRIPTION
There were a couple values bugs resulting in no uploads to r2 in the staging environment.
See commits for specific information