### PR TITLE
Fix/incorrect lotus tags

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/bootstrap/values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: mainnet-v1.18.0
+  tag: v1.18.0
 
 prometheusOperatorServiceMonitor: true
 

--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/disputer/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/disputer/values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: mainnet-v1.18.0
+  tag: v1.18.0
 
 prometheusOperatorServiceMonitor: true
 

--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/fullnode/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/fullnode/values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: mainnet-v1.18.0
+  tag: v1.18.0
 
 prometheusOperatorServiceMonitor: true
 

--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/lightweight-snapshot-node/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/lightweight-snapshot-node/values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: mainnet-v1.18.0
+  tag: v1.18.0
 
 prometheusOperatorServiceMonitor: true
 


### PR DESCRIPTION
Looks like there's a bit of a mismatch between travisrepo tags and filecoin tags


[travisperson/lotus](https://hub.docker.com/r/travisperson/lotus/tags) contains network specific tags e.g. [mainnet-v1.18.0](https://hub.docker.com/layers/travisperson/lotus/mainnet-v1.18.0/images/sha256-285c110cc6ab53ba81f8639894a7e9adf2492067f961d00a33582e0faaaa5aa1?context=explore)

[filecoin/lotus-all-in-one](https://hub.docker.com/r/filecoin/lotus-all-in-one/tags) contains network agnostic tags only e.g. [v1.18.0](https://hub.docker.com/layers/filecoin/lotus-all-in-one/v1.18.0/images/sha256-3d0ef34fb5917b0a03a5fb9f70ea54cc2da442964926de3967489c088266c614?context=explore) 

These workloads are leveraging filecoin, but the tag is still using the network-version tagscheme, currently exclusive to travisperson/lotus, hence not finding the image