### PR TITLE
latest filecoin-chain-archiver helm chart fixes naming issues

### DIFF
--- a/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/helmrelease.yaml
+++ b/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
         apiVersion: source.toolkit.fluxcd.io/v1beta1
         kind: HelmRepository
         name: filecoin-project-charts
-      version: 1.0.3
+      version: 1.0.4
   interval: 1m0s
   # The values are merged in the order given, with the later values overwriting earlier. These values always have a lower priority
   valuesFrom:


### PR DESCRIPTION
upgrading to this will fix cronjobs to reset the datastores, which is currently broken with 1.0.3