### PR TITLE
missing env vars for filecoin chain archiver

### DIFF
--- a/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver.yaml
+++ b/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver.yaml
@@ -32,6 +32,10 @@ snapshots:
   additionalEnv:
   - name: "GOLOG_LOG_FMT"
     value: "json"
+  - name: "FCA_CREATE_PROGRESS_UPDATE"
+    value: "60s"
+  - name: "FCA_CREATE_NAME_PREFIX"
+    value: "minimal/"
 
 nodelocker:
   additionalEnv:


### PR DESCRIPTION
sets the prefix/directory name in r2 bucket

updates progress every 60s in logs