### PR TITLE
include key values in additionalEnv, because base values don't merge

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -21,3 +21,9 @@ snapshots:
   additionalEnv:
   - name: "FCA_CREATE_RETRIEVAL_ENDPOINT_PREFIX"
     value: "https://pub-72366a891cfb4f1d8d3d518390c52e6e.r2.dev"
+  - name: "FCA_CREATE_PROGRESS_UPDATE"
+    value: "60s"
+  - name: "FCA_CREATE_NAME_PREFIX"
+    value: "minimal/"
+  - name: "GOLOG_LOG_FMT"
+    value: "json"

--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -21,3 +21,9 @@ snapshots:
   additionalEnv:
   - name: "FCA_CREATE_RETRIEVAL_ENDPOINT_PREFIX"
     value: "https://pub-125dc2d5e54f44e4af7593c5b2985ec1.r2.dev"
+  - name: "FCA_CREATE_PROGRESS_UPDATE"
+    value: "60s"
+  - name: "FCA_CREATE_NAME_PREFIX"
+    value: "minimal/"
+  - name: "GOLOG_LOG_FMT"
+    value: "json"


### PR DESCRIPTION
with the way helm deployments work, snapshots.additionalEnv lists do not merge, but get overridden instead by the tenant values file. this causes key env variables to remain unset in the final cronjob for lightweight lotus snapshots