### PR TITLE
update to the minimum go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,8 +403,8 @@ jobs:
       - run:
           name: install golang
           command: |
-            curl -LOs https://golang.org/dl/go1.18.1.linux-amd64.tar.gz
-            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz
+            curl -LOs https://golang.org/dl/go1.18.8.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.8.linux-amd64.tar.gz
       # - go/install:
       #   # ensure that the cache key matches the go version to clean up lingering source files
       #   # that may not be compatable across versions. Golang recommend to always uninstall the
@@ -674,8 +674,8 @@ jobs:
       - run:
           name: install golang
           command: |
-            curl -LOs https://golang.org/dl/go1.18.1.linux-amd64.tar.gz
-            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz
+            curl -LOs https://golang.org/dl/go1.18.8.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.8.linux-amd64.tar.gz
       # - go/install:
       #     version: 1.16.5
       #     cache-key: v1.16.5


### PR DESCRIPTION
Updates go version to 1.18.8 which is now the minimum for lotus
