### PR TITLE
use buster

### DIFF
--- a/docker/Dockerfile.binarybuilder
+++ b/docker/Dockerfile.binarybuilder
@@ -1,4 +1,4 @@
-FROM golang:1.18.8-bullseye AS builder
+FROM golang:1.18.8-buster AS builder
 MAINTAINER Filecoin Development Team
 
 RUN apt-get update && apt-get install -y ca-certificates build-essential clang jq ocl-icd-opencl-dev ocl-icd-libopencl1 libhwloc-dev

--- a/docker/Dockerfile.lotus
+++ b/docker/Dockerfile.lotus
@@ -4,7 +4,7 @@ ARG BUILDER_BASE=builder-local
 # builder-base
 # ---------------------
 
-FROM golang:1.18.8 AS builder-deps
+FROM golang:1.18.8-buster AS builder-deps
 MAINTAINER Lotus Development Team
 
 RUN apt-get update && apt-get install -y ca-certificates build-essential clang ocl-icd-opencl-dev ocl-icd-libopencl1 jq libhwloc-dev


### PR DESCRIPTION
bullseye uses libhwloc15, which is too recent for our devnets. buster is still on libhwloc5
