### PR TITLE
disputer node - upgrade lotus-fullnode chart

### DIFF
--- a/kubernetes/gitops/prod/ap-southeast-1/calibrationnet/base/disputer/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/calibrationnet/base/disputer/fullnode-helmrelease-patch.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   chart:
     spec:
-      version: 0.3.5
+      version: 0.4.2

--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/disputer/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/disputer/fullnode-helmrelease-patch.yaml
@@ -7,4 +7,4 @@ spec:
     timeout: "90m"
   chart:
     spec:
-      version: 0.3.5
+      version: 0.4.2


### PR DESCRIPTION
fixes a nodeSelector bug in 0.3.5 causing our helm release to break upgrade to 0.4.2