### PR TITLE
enable the lightweight snapshot chain archiver

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/calibrationnet/tenant/kustomization.yaml
+++ b/kubernetes/gitops/prod/us-east-1/calibrationnet/tenant/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
 - ../../../../base/applications/common
 - fullnode
 - bootstrap
+- lightweight-snapshot-chain-archiver
 - lightweight-snapshot-node
 - stats-dashboard

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/kustomization.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - bootstrap
 - disputer
 - gateway
+- lightweight-snapshot-chain-archiver
 - lightweight-snapshot-node
 - stats-dashboard
 - lotus-stats


### PR DESCRIPTION
start running snapshots when the associated lotus node pool is fully synced