### PR TITLE
update the image repository for 1.20.0-rc2 testing

### DIFF
--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
@@ -1,4 +1,5 @@
 image:
+  repository: filecoin/lotus-all-in-one
   tag: v1.20.0-rc2
 secrets:
   libp2p:

--- a/kubernetes/gitops/prod/eu-central-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
@@ -1,4 +1,5 @@
 image:
+  repository: filecoin/lotus-all-in-one
   tag: v1.20.0-rc2
 secrets:
   libp2p:

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
@@ -1,4 +1,5 @@
 image:
+  repository: filecoin/lotus-all-in-one
   tag: v1.20.0-rc2
 secrets:
   libp2p:


### PR DESCRIPTION
these bootstrap nodes are still using an older version of the lotus-fullnode chart, that still defaults to the old docker image