### PR TITLE
scaling and testin load balancing of index resolver

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -3,14 +3,22 @@ image:
   tag: "1.1.1"
 
 indexResolver:
-  replicas: 1
+  replicas: 3
   s3Resolver:
     bucket: "filecoin-snapshots-calibnet-production"
     endpoint: "https://eafecb340a3ce23027e1eba779ed4d91.r2.cloudflarestorage.com"
     secretName: r2-access
 
   loadBalancer:
-    enabled: false
+    enabled: true
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+      # THIS SSL CERT IS FOR snapshots.mainnet.filops.net
+      # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:759815798766:certificate/5e9eb742-7d50-4ac9-b1e2-4fe4c1f5f5a1
+      # service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+      external-dns.alpha.kubernetes.io/hostname: snapshots2.mainnet.filops.net
+      external-dns.alpha.kubernetes.io/alias: "true"
+      external-dns.alpha.kubernetes.io/ttl: "60"
 
 snapshots:
   uploads:


### PR DESCRIPTION
once this configuration is successfully deployed and validated, the final DNS cut-over can be made, replacing the old index resolver service in legacy cluster