### PR TITLE
upgrade to lotus v1.20.0 on a bootstrap node per region

### DIFF
--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: filecoin/lotus-all-in-one
-  tag: v1.20.0-rc2
+  tag: v1.20.0
 secrets:
   libp2p:
     enabled: true

--- a/kubernetes/gitops/prod/eu-central-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: filecoin/lotus-all-in-one
-  tag: v1.20.0-rc2
+  tag: v1.20.0
 secrets:
   libp2p:
     enabled: true

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/bootstrap/bootstrap-0/fullnode-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: filecoin/lotus-all-in-one
-  tag: v1.20.0-rc2
+  tag: v1.20.0
 secrets:
   libp2p:
     enabled: true


### PR DESCRIPTION
these lotus nodes are already running RCs, so upgrading to stable should be safe enough, for canary testing. other bootstrap nodes should remain on v1.18.0 until validation is complete on these nodes