### PR TITLE
us-east-1: upgrade lotus-bundle chart to fix sync issues

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
@@ -1,7 +1,8 @@
-# apiVersion: helm.toolkit.fluxcd.io/v2beta1
-# kind: HelmRelease
-# metadata:
-#   name: gateway
-# spec:
-#   install:
-#     timeout: "90m"
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: gateway
+spec:
+  chart:
+    spec:
+      version: 0.0.22


### PR DESCRIPTION
the behavior of the old chart is causing sync issues (not exiting on failed import)