### PR TITLE
lws: decrease the activeDeadlineSeconds for faster failures

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -20,7 +20,7 @@ indexResolver:
       external-dns.alpha.kubernetes.io/ttl: "60"
 
 snapshots:
-  activeDeadlineSeconds: 21600 # 6 hours
+  activeDeadlineSeconds: 18000 # 5 hours
   uploads:
     enabled: true
     bucket: "filecoin-snapshots-mainnet-production"


### PR DESCRIPTION
the 6h timeout is resulting in long intervals between jobs when failures occur, causing long gaps between successful jobs.

decrease timeout so jobs will fail faster (but not timeout prematurely)