### PR TITLE
extend the timeout, to be rougly twice the execution time

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -20,7 +20,7 @@ indexResolver:
       external-dns.alpha.kubernetes.io/ttl: "60"
 
 snapshots:
-  activeDeadlineSeconds: 18000 # 5 hours
+  activeDeadlineSeconds: 28800 # 8 hours
   uploads:
     enabled: true
     bucket: "filecoin-snapshots-mainnet-production"


### PR DESCRIPTION
completed jobs are taking between 3-4 hours, so kill a job if we know another will soon be following so we don't overwrite a newer 'latest' snapshot entry