### PR TITLE
disable fullnode upgrade remediation

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/fullnode/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/fullnode/fullnode-helmrelease-patch.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   install:
     timeout: "90m"
+  upgrade:
+    # XXX: Temporary to prevent fullnode rollback
+    remediateLastFailure: false
+    retries: 0
   chart:
     spec:
       version: 0.4.2


### PR DESCRIPTION
- Disable fullnode upgrade remediation

Allow the helmrelease to fail due to timeout, I'll manually babysit it
until it's upgraded then we can reset this if we see it as useful
