### PR TITLE
temporary only: test out filecoin-chain-archiver with no reboot

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: Always
-  tag: "1.1.1"
+  tag: "pr-59"
 
 indexResolver:
   replicas: 1


### PR DESCRIPTION
temporary fix to restore snapshot service. currently the filecoin-chain-archiver create command is getting websocket timeouts after exactly 30s