### PR TITLE
rollback lotus to v1.18.0 to restore snapshot service

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/lightweight-snapshot-node/values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/lightweight-snapshot-node/values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v1.20.1
+  tag: v1.18.0
 
 prometheusOperatorServiceMonitor: true
 


### PR DESCRIPTION
a change in recent lotus releases effects a sleep in filecoin-chain-archiver, causing the job to be run too early, causing silent quits