### PR TITLE
upgrade to lotus-bundle 0.0.23 to enable metrics

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/gateway/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/gateway/gateway-helmrelease-patch.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   chart:
     spec:
-      version: 0.0.22
+      version: 0.0.23
   # XXX: Temporary to try to fix stuck reconciliation
   interval: 10m


### PR DESCRIPTION
older versions of the helm chart don't ship with a service monitor or the lotus api port mapping