### PR TITLE
uses podmonitor instead of servicemonitor

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/gateway/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/gateway/gateway-helmrelease-patch.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   chart:
     spec:
-      version: 0.0.24
+      version: 0.0.25
   # XXX: Temporary to try to fix stuck reconciliation
   interval: 10m


### PR DESCRIPTION
we don't want to add a service only for prometheus scraping.

this version of lotus-bundle uses a PodMonitor