### PR TITLE
Upgrade calibnet gateway chart version

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/gateway/staging-api-chain-love/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/gateway/staging-api-chain-love/gateway-helmrelease-patch.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   chart:
     spec:
-      version: 0.1.3-rc0
+      version: 0.1.3-rc1
   # XXX: Temporary to try to fix stuck reconciliation
   interval: 10m

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/gateway/staging-api-chain-love/values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/gateway/staging-api-chain-love/values.yaml
@@ -14,6 +14,10 @@ volumeClaimTemplates:
     resources:
       requests:
         storage: 20Gi
+
+snapshotImporter:
+  snapshotUrl: "https://snapshots.calibrationnet.filops.net/minimal/latest"
+
 application:
   name: lotus-gateway-ethrpc
   labels: []


### PR DESCRIPTION
- This version allows us to set the snapshot url for the importer
  which is required because this is the first calibnet gateway,
  and it wasn't working because the importer was statically configured
  to import the mainnet snapshot
