### PR TITLE
fix/fullnode storage class as1

### DIFF
--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/bootstrap/values.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/bootstrap/values.yaml
@@ -17,7 +17,6 @@ persistence:
     enabled: true
     easyReset: true
     size: "2000Gi"
-    storageClassName: "gp2"
 
 daemonConfig: |
   [API]


### PR DESCRIPTION
- Set base bootstrap chart version to 0.4.3
- Remove gp2 hardcoding for bootstrap nodes
