### PR TITLE
feat/upgrade bootstrap storage

### DIFF
--- a/kubernetes/gitops/prod/eu-central-1/mainnet/base/bootstrap/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/base/bootstrap/fullnode-helmrelease-patch.yaml
@@ -2,9 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: fullnode
-spec:
-  install:
-    timeout: "90m"
-  chart:
-    spec:
-      version: 0.4.2
+spec: {}

--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/bootstrap/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/bootstrap/fullnode-helmrelease-patch.yaml
@@ -2,9 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: fullnode
-spec:
-  install:
-    timeout: "90m"
-  chart:
-    spec:
-      version: 0.4.2
+spec: {}


### PR DESCRIPTION
- Remove gp2 storageclass from base fullnode config
- Update base bootstrap nodes to 0.4.3
