### PR TITLE
Enable ethrpc on gateways

### DIFF
--- a/kubernetes/gitops/base/applications/gateway/helmrelease.yaml
+++ b/kubernetes/gitops/base/applications/gateway/helmrelease.yaml
@@ -18,9 +18,9 @@ spec:
         apiVersion: source.toolkit.fluxcd.io/v1beta1
         kind: HelmRepository
         name: filecoin-project-charts
-      version: 0.0.21
+      version: 0.1.3-rc3
   interval: 1m0s
-  # The values are merged in the order given, with the later values overwriting earlier. These values always have a lower priority 
+  # The values are merged in the order given, with the later values overwriting earlier. These values always have a lower priority
   valuesFrom:
   - kind: ConfigMap
     name: gateway-common-values

--- a/kubernetes/gitops/base/applications/gateway/values.yaml
+++ b/kubernetes/gitops/base/applications/gateway/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   repository: filecoin/lotus-all-in-one
-  tag: v1.19.0
+  tag: v1.20.3-rpc-p01-hf02
   pullPolicy: Always
 
 application:
@@ -56,14 +56,30 @@ application:
 
 lotus:
   enabled: true
-  image: filecoin/lotus-all-in-one:v1.19.0
-  lite:
-    enabled: false
+  image: docker.io/filecoin/lotus-all-in-one:v1.20.3-rpc-p01-hf02
+  extraEnv:
+    LOTUS_API_LISTENADDRESS: /ip4/0.0.0.0/tcp/1234/http
+    LOTUS_FEVM_ENABLEETHRPC: "true"
   reset:
     enabled: true
     percent: 90
+  extraVolumeMounts:
+  - name: lotus-sqlite
+    mountPath: /var/lib/lotus/sqlite
 
 prometheus:
   serviceMonitor: true
   path: /debug/metrics
   port: lotus-gw
+
+# volumeClaims:
+volumeClaimTemplates:
+- metadata:
+    name: lotus-sqlite
+  spec:
+    storageClassName: gp3-retain
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 20G

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/base/gateway/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/base/gateway/gateway-helmrelease-patch.yaml
@@ -2,7 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gateway
-spec:
-  chart:
-    spec:
-      version: 0.1.2
+spec: {}

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/gateway/staging-api-chain-love/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/gateway/staging-api-chain-love/gateway-helmrelease-patch.yaml
@@ -2,9 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gateway
-spec:
-  chart:
-    spec:
-      version: 0.1.3-rc1
-  # XXX: Temporary to try to fix stuck reconciliation
-  interval: 10m
+spec: {}

--- a/kubernetes/gitops/dev/us-east-2/mainnet/base/gateway/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/base/gateway/gateway-helmrelease-patch.yaml
@@ -2,9 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gateway
-spec:
-  chart:
-    spec:
-      version: 0.1.2
-  # XXX: Temporary to try to fix stuck reconciliation
-  interval: 10m
+spec: {}

--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
@@ -2,7 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gateway
-spec:
-  chart:
-    spec:
-      version: 0.1.2
+spec: {}

--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/tenant/gateway/ethrpc-chain-love/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/tenant/gateway/ethrpc-chain-love/gateway-helmrelease-patch.yaml
@@ -2,9 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gateway
-spec:
-  chart:
-    spec:
-      version: 0.1.3-rc3
-  # XXX: Temporary to try to fix stuck reconciliation
-  interval: 10m
+spec: {}

--- a/kubernetes/gitops/prod/eu-central-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
@@ -2,7 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gateway
-spec:
-  chart:
-    spec:
-      version: 0.1.2
+spec: {}

--- a/kubernetes/gitops/prod/eu-central-1/mainnet/tenant/gateway/ethrpc-chain-love/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/tenant/gateway/ethrpc-chain-love/gateway-helmrelease-patch.yaml
@@ -2,7 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gateway
-spec:
-  chart:
-    spec:
-      version: 0.1.3-rc3
+spec: {}

--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/gateway-helmrelease-patch.yaml
@@ -2,7 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gateway
-spec:
-  chart:
-    spec:
-      version: 0.1.2
+spec: {}

--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/values.yaml
@@ -1,7 +1,34 @@
 image:
+  repository: filecoin/lotus-all-in-one
   tag: v1.20.3-rpc-p01-hf02 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release:tag"}
+  pullPolicy: Always
 
 lotus:
+  enabled: true
   image: docker.io/filecoin/lotus-all-in-one:v1.20.3-rpc-p01-hf02 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release"}
   extraEnv:
     LOTUS_API_LISTENADDRESS: /ip4/0.0.0.0/tcp/1234/http
+    LOTUS_FEVM_ENABLEETHRPC: "true"
+  reset:
+    enabled: true
+    percent: 90
+  extraVolumeMounts:
+  - name: lotus-sqlite
+    mountPath: /var/lib/lotus/sqlite
+
+# volumeClaims:
+volumeClaimTemplates:
+- metadata:
+    name: lotus-sqlite
+  spec:
+    storageClassName: gp3-retain
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 20G
+
+prometheus:
+  serviceMonitor: true
+  path: /debug/metrics
+  port: lotus-gw

--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/lotus-stats/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/lotus-stats/gateway-helmrelease-patch.yaml
@@ -1,7 +1,5 @@
-# apiVersion: helm.toolkit.fluxcd.io/v2beta1
-# kind: HelmRelease
-# metadata:
-#   name: lotus-stats
-# spec:
-#   install:
-#     timeout: "90m"
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: gateway
+spec: {}

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/gateway/ethrpc-chain-love/gateway-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/gateway/ethrpc-chain-love/gateway-helmrelease-patch.yaml
@@ -2,9 +2,4 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gateway
-spec:
-  chart:
-    spec:
-      version: 0.1.3-rc3
-  # XXX: Temporary to try to fix stuck reconciliation
-  interval: 10m
+spec: {}


### PR DESCRIPTION
- Update the base gateway values to support ethrpc
- Remove all helmrelease patching from gateway tenants to normalise them
 
Deployment strategy:
All gateways are currently suspended. I'll resume them one by one to make sure they don't go offline at once if something is wrong.