### PR TITLE
hotfix/nv20 wdpost failure snapshot intervention

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/calibrationnet/base/lightweight-snapshot-node/values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/calibrationnet/base/lightweight-snapshot-node/values.yaml
@@ -1,7 +1,7 @@
 image:
   # Set version to fix fork incident
   # https://www.notion.so/pl-strflt/nv20-wdpost-failure-7ec6d48afe1441c59940ef58dde721d7#4b486515a23145ae9af0b4f4dd4b48cb
-  tag: v1.22.0
+  tag: v1.22.0-calibnet
 prometheusOperatorServiceMonitor: true
 resources:
   requests:


### PR DESCRIPTION
- Set snapshot nodes to v1.22.0
- Fix image
