### PR TITLE
try out FCA version that only uploads compressed snapshots

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: Always
-  tag: "pr-67"
+  tag: "pr-69"
 
 indexResolver:
   replicas: 1


### PR DESCRIPTION
raw CAR snapshots will be deprecated on May 15.

test filecoin-chain-archiver updates that remove raw CAR uploads