### PR TITLE
re-enable uploads in staging

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -16,7 +16,7 @@ snapshots:
   activeDeadlineSeconds: 28800 # 8 hours
   schedule: "0 */12 * * *"
   uploads:
-    enabled: false
+    enabled: true
     bucket: "filecoin-snapshots-mainnet-staging"
     endpoint: "https://eafecb340a3ce23027e1eba779ed4d91.r2.cloudflarestorage.com"
     secretName: r2-access


### PR DESCRIPTION
preliminary testing of the new FCA version that deprecates raw car snapshots was successful. let's actually upload the file now