### PR TITLE
dev calibnet bootstrap to use gp3

### DIFF
--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/base/bootstrap/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/base/bootstrap/fullnode-helmrelease-patch.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   chart:
     spec:
-      version: 0.4.2
+      version: 0.4.3


### PR DESCRIPTION
- Bump dev calibnet bootstrap chart to 0.4.3
