### PR TITLE
lws: deploy filecoin-chain-archiver 1.3.0 to deprecate raw cars

### DIFF
--- a/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver.yaml
+++ b/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "1.1.1"
+  tag: "1.3.0"
 
 indexResolver:
   replicas: 0

--- a/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: Always
-  tag: "pr-67"
+  tag: "1.3.0"
 
 indexResolver:
   replicas: 1

--- a/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/dev/us-east-2/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: Always
-  tag: "1.3.0-rc0"
+  tag: "1.3.0"
 
 indexResolver:
   replicas: 1

--- a/kubernetes/gitops/prod/us-east-1/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/calibrationnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: Always
-  tag: "1.1.1"
+  tag: "1.3.0"
 
 indexResolver:
   replicas: 3

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: Always
-  tag: "1.2.0"
+  tag: "1.3.0"
 
 indexResolver:
   replicas: 3


### PR DESCRIPTION
FCA 1.3.0 is the new baseline tag to use, making raw CAR files deprecated moving forward.

This will reduce costs and bandwidth for both PL and all users