### PR TITLE
Add cron metrics to FCA and volume-snapshotter

### DIFF
--- a/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/helmrelease.yaml
+++ b/kubernetes/gitops/base/applications/lightweight-snapshot-chain-archiver/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
         apiVersion: source.toolkit.fluxcd.io/v1beta1
         kind: HelmRepository
         name: filecoin-project-charts
-      version: 1.0.6
+      version: 1.0.7
   interval: 1m0s
   # The values are merged in the order given, with the later values overwriting earlier. These values always have a lower priority
   valuesFrom:

--- a/kubernetes/gitops/base/applications/volume-snapshotter/helmrelease.yaml
+++ b/kubernetes/gitops/base/applications/volume-snapshotter/helmrelease.yaml
@@ -18,9 +18,9 @@ spec:
         apiVersion: source.toolkit.fluxcd.io/v1beta1
         kind: HelmRepository
         name: filecoin-project-charts
-      version: 0.1.1
+      version: 0.1.2
   interval: 1m0s
-  # The values are merged in the order given, with the later values overwriting earlier. These values always have a lower priority 
+  # The values are merged in the order given, with the later values overwriting earlier. These values always have a lower priority
   valuesFrom:
   - kind: ConfigMap
     name: volume-snapshotter-common-values


### PR DESCRIPTION
Partly releases filecoin-project/lotus-infra-archive#415

We're only running these two cronjobs out of the updated charts
