### PR TITLE
lws: scale-down lotus pool

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -39,8 +39,8 @@ snapshots:
   - /dns/lws-node-0-fullnode-lotus-daemon/tcp/1234
   - /dns/lws-node-1-fullnode-lotus-daemon/tcp/1234
   - /dns/lws-node-2-fullnode-lotus-daemon/tcp/1234
-  - /dns/lws-node-3-fullnode-lotus-daemon/tcp/1234
-  - /dns/lws-node-4-fullnode-lotus-daemon/tcp/1234
+  # - /dns/lws-node-3-fullnode-lotus-daemon/tcp/1234
+ #  - /dns/lws-node-4-fullnode-lotus-daemon/tcp/1234
   schedule: "*/120 * * * *"
   resources:
     requests:
@@ -63,12 +63,12 @@ snapshots:
           topologyKey: kubernetes.io/hostname
 podResets:
   - pod: lws-node-0-fullnode-lotus-0
-    schedule: "0 0 * * 0,2,4"
+    schedule: "0 0 * * 0"
   - pod: lws-node-1-fullnode-lotus-0
-    schedule: "0 8 * * 0,2,4"
+    schedule: "0 0 * * 2"
   - pod: lws-node-2-fullnode-lotus-0
-    schedule: "0 16 * * 0,2,4"
-  - pod: lws-node-3-fullnode-lotus-0
-    schedule: "0 12 * * 1,3,6"
-  - pod: lws-node-4-fullnode-lotus-0
-    schedule: "0 0 * * 1,3,6"
+    schedule: "0 0 * * 4"
+#  - pod: lws-node-3-fullnode-lotus-0
+#    schedule: "0 12 * * 1,3,6"
+#  - pod: lws-node-4-fullnode-lotus-0
+#    schedule: "0 0 * * 1,3,6"

--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-node/kustomization.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-node/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
 - fullnode-0
 - fullnode-1
 - fullnode-2
-- fullnode-3
-- fullnode-4
+# - fullnode-3
+# - fullnode-4
 - node-jwt-secret.yaml


### PR DESCRIPTION
now that lightweight snapshot service performance has stabilized and raw car file generation is deprecated, we don't need to 5 lotus nodes in our snapshot pool.

reduce to 3 nodes and make associated configuration changes.

also the datastore growth has slowed significantly, so let's only clear the datastores once a week