### PR TITLE
Fix incorrect FCA cron

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/tenant/lightweight-snapshot-chain-archiver/lightweight-snapshot-chain-archiver-values.yaml
@@ -41,7 +41,7 @@ snapshots:
   - /dns/lws-node-2-fullnode-lotus-daemon/tcp/1234
   # - /dns/lws-node-3-fullnode-lotus-daemon/tcp/1234
  #  - /dns/lws-node-4-fullnode-lotus-daemon/tcp/1234
-  schedule: "*/120 * * * *"
+  schedule: "0 */2 * * *"
   resources:
     requests:
       cpu: "1500m"


### PR DESCRIPTION
- Fix cron to run every 2h rather than every 120m
- It appears that the minute is module 60 so 120 == 60
