### PR TITLE
fix/default fullnode splitstore to false

### DIFF
--- a/kubernetes/gitops/base/applications/fullnode/values.yaml
+++ b/kubernetes/gitops/base/applications/fullnode/values.yaml
@@ -23,3 +23,5 @@ daemonConfig: |
     ListenAddress = "/ip4/0.0.0.0/tcp/1234/http"
   [Libp2p]
     ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]
+  [Chainstore]
+    EnableSplitstore = false


### PR DESCRIPTION
- Lotus 1.23.3 requires this field to be specified
- Set base fullnode app to set this to false
- Ideally it should be set to true, and overridden for the archival nodes,
  however due to a conflation in terms between a "full archival node" and
  a "full node", the latter meaning "not a lite node", the configuration
  would become very confusing if we used true as the base condition and
  increase the risk of tanking our full archival nodes.
