### PR TITLE
Increase sqlite volume by 5gb

### DIFF
--- a/kubernetes/gitops/base/applications/gateway/values.yaml
+++ b/kubernetes/gitops/base/applications/gateway/values.yaml
@@ -98,4 +98,4 @@ volumeClaimTemplates:
     - ReadWriteOnce
     resources:
       requests:
-        storage: 20G
+        storage: 25G


### PR DESCRIPTION
- Lotus is failing to migrate the events store due to it needing more
  than 40% more disk space.
- The fix will take a while to produce so we're scaling up to proceed
  with the upgrade
