### PR TITLE
Upgrade prod gateways to 1.23.3

### DIFF
--- a/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/gateway/values.yaml
+++ b/kubernetes/gitops/prod/ap-southeast-1/mainnet/base/gateway/values.yaml
@@ -1,15 +1,6 @@
 ---
 image:
-  tag: v1.22.1 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release:tag"}
+  tag: v1.23.3 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release:tag"}
 
 lotus:
-  image: docker.io/filecoin/lotus-all-in-one:v1.22.1 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release"}
-
-  extraEnv:
-    LOTUS_API_LISTENADDRESS: /ip4/0.0.0.0/tcp/1234/http
-    LOTUS_FEVM_ENABLEETHRPC: "true"
-    LOTUS_CHAINSTORE_ENABLESPLITSTORE: "true"
-    LOTUS_CHAINSTORE_SPLITSTORE_COLDSTORETYPE: "discard"
-    ## We need 4 finalities: 1 finality = 900 epochs, 1 epoch = 30s
-    ## Finalities required for 24h of data: 24h / (900epochs * 30s / 3600s) = 3.2
-    LOTUS_CHAINSTORE_SPLITSTORE_HOTSTOREMESSAGERETENTION: "4"
+  image: docker.io/filecoin/lotus-all-in-one:v1.23.3 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release"}

--- a/kubernetes/gitops/prod/eu-central-1/mainnet/base/gateway/values.yaml
+++ b/kubernetes/gitops/prod/eu-central-1/mainnet/base/gateway/values.yaml
@@ -1,15 +1,5 @@
----
 image:
-  tag: v1.22.1 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release:tag"}
+  tag: v1.23.3 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release:tag"}
 
 lotus:
-  image: docker.io/filecoin/lotus-all-in-one:v1.22.1 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release"}
-
-  extraEnv:
-    LOTUS_API_LISTENADDRESS: /ip4/0.0.0.0/tcp/1234/http
-    LOTUS_FEVM_ENABLEETHRPC: "true"
-    LOTUS_CHAINSTORE_ENABLESPLITSTORE: "true"
-    LOTUS_CHAINSTORE_SPLITSTORE_COLDSTORETYPE: "discard"
-    ## We need 4 finalities: 1 finality = 900 epochs, 1 epoch = 30s
-    ## Finalities required for 24h of data: 24h / (900epochs * 30s / 3600s) = 3.2
-    LOTUS_CHAINSTORE_SPLITSTORE_HOTSTOREMESSAGERETENTION: "4"
+  image: docker.io/filecoin/lotus-all-in-one:v1.23.3 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release"}

--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/values.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/gateway/values.yaml
@@ -1,15 +1,6 @@
 ---
 image:
-  tag: v1.22.1 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release:tag"}
+  tag: v1.23.3 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release:tag"}
 
 lotus:
-  image: docker.io/filecoin/lotus-all-in-one:v1.22.1 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release"}
-
-  extraEnv:
-    LOTUS_API_LISTENADDRESS: /ip4/0.0.0.0/tcp/1234/http
-    LOTUS_FEVM_ENABLEETHRPC: "true"
-    LOTUS_CHAINSTORE_ENABLESPLITSTORE: "true"
-    LOTUS_CHAINSTORE_SPLITSTORE_COLDSTORETYPE: "discard"
-    ## We need 4 finalities: 1 finality = 900 epochs, 1 epoch = 30s
-    ## Finalities required for 24h of data: 24h / (900epochs * 30s / 3600s) = 3.2
-    LOTUS_CHAINSTORE_SPLITSTORE_HOTSTOREMESSAGERETENTION: "4"
+  image: docker.io/filecoin/lotus-all-in-one:v1.23.3 # {"$imagepolicy": "ntwk-mainnet:lotus-latest-release"}


### PR DESCRIPTION
- The base helm chart has updated (release are suspended atm) to include the configuration injected as a file, so we can drop the env vars to minimise duplication/confusion.
- Bump the versions to 1.23.3
- I'm going to manually increase the sqlite volume size to 25Gi (see https://github.com/filecoin-project/lotus/issues/11227) before resuming as in some cases the size update doesn't trickle down to the PV
