### PR TITLE
Hotfix: Increase gateway datastore by 50Gi

### DIFF
--- a/kubernetes/gitops/base/applications/gateway/values.yaml
+++ b/kubernetes/gitops/base/applications/gateway/values.yaml
@@ -60,6 +60,7 @@ application:
 
 lotus:
   enabled: true
+  storage: 550Gi
   reset:
     enabled: true
     percent: 90


### PR DESCRIPTION
Responding to incident:
  https://protocollabs.app.opsgenie.com/alert/detail/
  a211d4c2-7b5a-4636-82b7-ab4c8aa7bdc3-1695602835063/details

PVCs show to have maxed out
