### PR TITLE
Increase chain.love disk to 800gi

### DIFF
--- a/kubernetes/gitops/base/applications/gateway/values.yaml
+++ b/kubernetes/gitops/base/applications/gateway/values.yaml
@@ -60,7 +60,7 @@ application:
 
 lotus:
   enabled: true
-  storage: 550Gi
+  storage: 800Gi
   reset:
     enabled: true
     percent: 90


### PR DESCRIPTION
This has already been actioned manually. STSs can't be updated, this
change is just to make sure the values match what's deployed, in case
we decide to redeploy entirely.
