### PR TITLE
Update Dockerfile to use Go v1.20.7

### DIFF
--- a/docker/Dockerfile.binarybuilder
+++ b/docker/Dockerfile.binarybuilder
@@ -3,7 +3,7 @@ MAINTAINER Filecoin Development Team
 
 RUN apt-get update && apt-get install -y ca-certificates build-essential clang jq ocl-icd-opencl-dev ocl-icd-libopencl1 libhwloc-dev curl wget pkg-config git
 
-ARG GOLANG_VERSION="1.19.12"
+ARG GOLANG_VERSION="1.20.7"
 ARG UID=1000
 ARG GID=1000
 ARG RUST_VERSION=nightly


### PR DESCRIPTION
Update Dockerfile to use Go v1.20.7