### PR TITLE
update fullnode helm chart for splitstore

### DIFF
--- a/kubernetes/gitops/prod/us-east-1/calibrationnet/base/fullnode/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/calibrationnet/base/fullnode/fullnode-helmrelease-patch.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   chart:
     spec:
-      version: 0.4.2
+      version: 0.4.3

--- a/kubernetes/gitops/prod/us-east-1/calibrationnet/base/lightweight-snapshot-node/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/calibrationnet/base/lightweight-snapshot-node/fullnode-helmrelease-patch.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   chart:
     spec:
-      version: 0.4.2
+      version: 0.4.3

--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/fullnode/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/fullnode/fullnode-helmrelease-patch.yaml
@@ -13,4 +13,4 @@ spec:
     timeout: 5m
   chart:
     spec:
-      version: 0.4.2
+      version: 0.4.3

--- a/kubernetes/gitops/prod/us-east-1/mainnet/base/lightweight-snapshot-node/fullnode-helmrelease-patch.yaml
+++ b/kubernetes/gitops/prod/us-east-1/mainnet/base/lightweight-snapshot-node/fullnode-helmrelease-patch.yaml
@@ -7,4 +7,4 @@ spec:
     timeout: "90m"
   chart:
     spec:
-      version: 0.4.2
+      version: 0.4.3


### PR DESCRIPTION
otherwise it crashes and burns, because splitstore needs to be explicitly set