### PR TITLE
missing acl package after ubuntu upgrade

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -15,6 +15,7 @@
       - jq
       - unzip
       - libhwloc-dev
+      - acl
 
 - name: Ensure hostname
   hostname:


### PR DESCRIPTION
without this package, ansible errors it when trying to become the fc user