### PR TITLE
Testing do-not-merge: Update butterfly-hosts

### DIFF
--- a/ansible/inventories/butterfly.fildev.network/hosts.yml
+++ b/ansible/inventories/butterfly.fildev.network/hosts.yml
@@ -21,13 +21,13 @@ all:
       children:
         preminer0:
           hosts:
-            preminer-0.butterfly.fildev.network:
+            ec2-54-221-161-132.compute-1.amazonaws.com:
         preminer1:
           hosts:
-            preminer-1.butterfly.fildev.network:
+            ec2-34-207-107-191.compute-1.amazonaws.com:
         preminer2:
           hosts:
-            preminer-2.butterfly.fildev.network:
+            ec2-34-228-241-196.compute-1.amazonaws.com:
         #preminer3:
         #  hosts:
         #    preminer-3.butterfly.fildev.network:
@@ -39,19 +39,19 @@ all:
         #    preminer-5.butterfly.fildev.network:
         bootstrap0:
           hosts:
-            bootstrap-0.butterfly.fildev.network:
+            ec2-54-225-12-123.compute-1.amazonaws.com:
         bootstrap1:
           hosts:
-            bootstrap-1.butterfly.fildev.network:
+            ec2-100-24-17-233.compute-1.amazonaws.com:
         toolshed0:
           hosts:
-            toolshed-0.butterfly.fildev.network:
+            ec2-34-201-220-22.compute-1.amazonaws.com:
         toolshed1:
           hosts:
-            toolshed-1.butterfly.fildev.network:
+            ec2-34-201-169-156.compute-1.amazonaws.com:
         scratch0:
           hosts:
-            scratch-0.butterfly.fildev.network:
+            ec2-54-236-14-224.compute-1.amazonaws.com:
         #scratch1:
         #  hosts:
         #    scratch-1.butterfly.fildev.network:


### PR DESCRIPTION
Update butterfly-hosts, to see if we can unblock nv22-testing. Got:

```
fatal: [toolshed-1.butterfly.fildev.network]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ssh: Could not resolve hostname toolshed-1.butterfly.fildev.network: Name or service not known", "unreachable": true}
fatal: [scratch-0.butterfly.fildev.network]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ssh: Could not resolve hostname scratch-0.butterfly.fildev.network: Name or service not known", "unreachable": true}
```

Which seems to come from that the fildev-aws account does not have the `toolshed-1.butterfly.fildev.network` / etc mapping/domain