### PR TITLE
Update Linux CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
         default: false
         description: append gitsha to image tag (useful when tag is master)
     machine:
-      image: default
+      image: current
     steps:
       - checkout
       - docker-login
@@ -152,7 +152,7 @@ jobs:
         type: boolean
         default: true
     machine:
-      image: default
+      image: current
       docker_layer_caching: true
     resource_class: 2xlarge
     environment:
@@ -294,7 +294,7 @@ jobs:
         default: "lotus"
     # binary building is done via a docker build image with a mounted filesystem
     machine:
-      image: default
+      image: current
       docker_layer_caching: true
     resource_class: 2xlarge
     environment:
@@ -423,7 +423,7 @@ jobs:
         type: boolean
         default: true
     machine:
-      image: default
+      image: current
       docker_layer_caching: true
     resource_class: 2xlarge
     environment:
@@ -522,7 +522,7 @@ jobs:
         type: string
         default: "#netops-circleci-test"
     machine:
-      image: default
+      image: current
       docker_layer_caching: true
     environment:
       AWS_REGION: << parameters.aws_region >>

--- a/docker/Dockerfile.binarybuilder
+++ b/docker/Dockerfile.binarybuilder
@@ -2,7 +2,7 @@ FROM ubuntu:20.04 AS builder
 MAINTAINER Filecoin Development Team
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev wget
+RUN apt-get update && apt-get install -y ca-certificates build-essential clang jq ocl-icd-opencl-dev ocl-icd-libopencl1 libhwloc-dev curl wget pkg-config git
 
 ARG GOLANG_VERSION="1.20.7"
 ARG UID=1000


### PR DESCRIPTION
When trying to reset the Butterfly-network, I encountered that the [CircleCI job was rejected](https://app.circleci.com/pipelines/github/filecoin-project/lotus-infra/4001/workflows/c81c5ca6-1e34-494e-a675-1733aa1628b1/jobs/2391) because the image is [unavailable](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/).

Updating the images, to see if that fixes the issue.