### PR TITLE
ci: update ssh key

### DIFF
--- a/ansible/roles/ssh_keys/files/public-keys/github-actions
+++ b/ansible/roles/ssh_keys/files/public-keys/github-actions
@@ -1,1 +1,1 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM8SIvSVX1TddlOOLr/PLApccs2syPOUpQDM+EUSJEe7 github[bot]@github.com
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILvFRGgaAN9h01sac0tsgBGIYn3wtQhnQHqQ/DN/K4n+ github[bot]@github.com


### PR DESCRIPTION
For some reason, the key in secrets is not in the [right format](https://github.com/filecoin-project/lotus-infra/actions/runs/9937441938/job/27447810367) (log should show the PEM file `--- BEGIN ...`)
it might have been misconfigured or there is an issue on our side.

I'll be using a key we control and set up for now, then request the team to update the key if needed.