### PR TITLE
Add ansible playbook to expose metrics

### DIFF
--- a/ansible/expose_metrics.yml
+++ b/ansible/expose_metrics.yml
@@ -1,0 +1,14 @@
+---
+# This playbook exposes the prometheus metrics from lotus daemon publically.
+# Run it by running the command below having replaced <network-name> with either "butterfly" or "calibration":
+#
+#  $ ansible-playbook -i inventories/<network-name>.fildev.network/hosts.yml expose_metrics.yml
+#
+# By default, it only exposes them for bootstrap and preminder nodes.
+- name: Ensure dependencies are installed
+  hosts:
+    - bootstrap
+    - preminer
+  become: true
+  roles:
+    - debug_metrics

--- a/ansible/roles/debug_metrics/defaults/main.yml
+++ b/ansible/roles/debug_metrics/defaults/main.yml
@@ -1,0 +1,1 @@
+debug_metrics_enabled: true

--- a/ansible/roles/debug_metrics/meta/main.yml
+++ b/ansible/roles/debug_metrics/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: nginx

--- a/ansible/roles/debug_metrics/tasks/main.yml
+++ b/ansible/roles/debug_metrics/tasks/main.yml
@@ -1,0 +1,31 @@
+- name: Ensure web folder exists
+  file:
+    path: /var/www/{{ inventory_hostname }}/
+    state: directory
+    owner: www-data
+    mode: 0755
+
+- name: Allow HTTP traffic
+  ufw:
+    rule: allow
+    name: "Nginx HTTP"
+
+- name: Ensure debug-metrics nginx config is available
+  template:
+    src: ../templates/nginx-debug-metrics.conf.j2
+    dest: /etc/nginx/sites-available/debug-metrics.conf
+
+- name: Ensure debug-metrics is enabled
+  file:
+    src: /etc/nginx/sites-available/debug-metrics.conf
+    dest: /etc/nginx/sites-enabled/50-debug-metrics.conf
+    state: link
+  notify: reload_nginx
+  when: debug_metrics_enabled | bool == true
+
+- name: Ensure debug-metrics http site disabled
+  file:
+    path: /etc/nginx/sites-enabled/50-debug-metrics.conf
+    state: absent
+  notify: reload_nginx
+  when: debug_metrics_enabled | bool == false

--- a/ansible/roles/debug_metrics/templates/nginx-debug-metrics.conf.j2
+++ b/ansible/roles/debug_metrics/templates/nginx-debug-metrics.conf.j2
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+    server_name {{ inventory_hostname }};
+
+    location /debug/metrics {
+
+        proxy_pass http://localhost:1234/debug/metrics;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
Add playbook to explose prometheus metrics publicly, default for bootstrap and preminer nodes in butterflynet.