### PR TITLE
Simplify reset CI parameters

### DIFF
--- a/.github/actions/lotus-ansible-reset/action.yaml
+++ b/.github/actions/lotus-ansible-reset/action.yaml
@@ -1,11 +1,8 @@
 name: "Lotus Ansible Reset"
 description: "Composite action to reset Lotus using Ansible"
 inputs:
-  install_network:
-    description: "Install network"
-    required: true
-  deploy_network:
-    description: "Deploy network"
+  network:
+    description: "The network to reset, one of 'butterflynet', or 'calibnet' "
     required: true
   preseal:
     description: "Preseal"
@@ -28,14 +25,14 @@ inputs:
     required: false
     default: "0"
   check:
-    description: "Check"
+    description: "Dry-run ansible"
     required: false
     default: "true"
 
 runs:
   using: "composite"
   steps:
-    - name: Check Env
+    - name: Check environment
       shell: bash
       run: |
         if [ -z "$GOPATH" ]; then
@@ -46,24 +43,32 @@ runs:
           echo "::error::LOTUSROOT is not set"
           exit 1
         fi
-
+    - name: Setup environment variables
+      shell: bash
+      run: |
+        # Infer deploy network from network name to reduce unnecessary noise in actions inputs.
+        DEPLOY_NETWORK=$(
+          case ${{ inputs.network }} in
+          butterflynet) printf 'butterfly.fildev.network' ;;
+          calibnet) printf 'calibration.fildev.network' ;;
+          *) echo 'Unknown network: ${{ env.NETWORK }}' >&2; exit 1 ;;
+          esac
+        )
+        echo "DEPLOY_NETWORK=${DEPLOY_NETWORK}" >> $GITHUB_ENV
     - name: Install Lotus Software
       shell: bash
       working-directory: ${{ env.LOTUSROOT }}
-      env:
-        INSTALL_NETWORK: ${{ inputs.install_network }}
       run: |
         sudo apt-get update
         sudo apt-get install -y libhwloc-dev ocl-icd-opencl-dev pkg-config
         sudo ln -s /usr/lib/x86_64-linux-gnu/libhwloc.so.15 /usr/lib/x86_64-linux-gnu/libhwloc.so.5
-        GOFLAGS+=-tags=${INSTALL_NETWORK} make lotus-shed lotus-seed
+        GOFLAGS+=-tags=${{ inputs.network }} make lotus-shed lotus-seed
         sudo install -o root -g root -m 0755 ./lotus-seed ./lotus-shed /usr/local/bin
 
-    - name: Ansible Reset ${{ inputs.deploy_network }}
+    - name: Ansible Reset ${{ inputs.network }}
       shell: bash
       working-directory: ansible
       env:
-        DEPLOY_NETWORK: ${{ inputs.deploy_network }}
         BUILD_FLAGS: ${{ inputs.build_flags }}
         DELAY: ${{ inputs.delay }}
         RESET: ${{ inputs.reset }}
@@ -90,8 +95,6 @@ runs:
       if: ${{ inputs.check == 'false' }}
       shell: bash
       working-directory: ansible
-      env:
-        DEPLOY_NETWORK: ${{ inputs.deploy_network }}
       run: |
         ansible -i inventories/${DEPLOY_NETWORK}/hosts.yml -b -m file -a 'state=link src=/etc/nginx/sites-available/faucet.conf dest=/etc/nginx/sites-enabled/50-faucet.conf' faucet
 
@@ -99,8 +102,6 @@ runs:
       if: ${{ inputs.check == 'false' }}
       shell: bash
       working-directory: ansible
-      env:
-        DEPLOY_NETWORK: ${{ inputs.deploy_network }}
       run: |
         ansible -i inventories/${DEPLOY_NETWORK}/hosts.yml -b -m reboot all
 

--- a/.github/workflows/lotus-ansible-reset.yaml
+++ b/.github/workflows/lotus-ansible-reset.yaml
@@ -1,30 +1,26 @@
 name: Lotus Ansible Reset Careful
 
-# api_worflow_requested = lotus-devnet-ansible-reset
-# and be_careful = true
-
 on:
   workflow_dispatch:
     inputs:
-      lotus_install_network:
-        description: "network to build lotus tools"
+      network:
+        description: "Network:"
         default: "butterflynet"
-      lotus_deploy_network:
-        description: "network to find ansible host"
-        default: "butterfly.fildev.network"
-      lotus_branch:
-        description: "lotus branch"
+        type: choice
+        options:
+          - butterflynet
+          - calibnet
+      lotus_ref:
+        description: "Lotus git ref:"
         default: "master"
       dry-run:
-        description: "Run this workflow in dry-run mode first befure setting to false"
-        default: "true"
-        # if we ever switch to Github Enterprise or make this repository public,
-        # we can use an environment with required reviewers.
-        # then run two steps: one with check: true, and the other with check: false and the required env.
+        description: "Dry-run changes?"
+        type: boolean
+        default: true
 
 jobs:
   check:
-    runs-on: [self-hosted, linux, x64, 2xlarge]
+    runs-on: [ self-hosted, linux, x64, 2xlarge ]
     timeout-minutes: 35
     steps:
       - name: Checkout code
@@ -33,22 +29,21 @@ jobs:
       - name: Lotus Ansible Prepare
         uses: ./.github/actions/lotus-ansible-prepare
         with:
-          branch: ${{ github.event.inputs.lotus_branch || 'master' }}
+          branch: ${{ inputs.lotus_ref }}
           EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
           PRIVATE_SSH_KEY: ${{ secrets.PRIVATE_SSH_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-east-2"
+          AWS_REGION: "us-east-1"
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 
       - name: Lotus Ansible Reset
         uses: ./.github/actions/lotus-ansible-reset
         with:
-          deploy_network: ${{ github.event.inputs.lotus_deploy_network || 'butterfly.fildev.network' }}
-          install_network: ${{ github.event.inputs.lotus_install_network || 'butterflynet' }}
+          network: ${{ inputs.network }}
           preseal: "true"
           create_cert: "true"
           build_flags: ""
           reset: "true"
           delay: "0"
-          check: ${{ github.event.inputs.dry-run || 'true' }}
+          check: ${{ inputs.dry-run || 'true' }}


### PR DESCRIPTION
Infer "deploy network" from a simple network name and use consistent input naming across jobs.

Fixes #1611